### PR TITLE
Show progress bar on slow load, import or export

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -38,17 +38,26 @@ jobs:
         with:
           languages: 'cpp'
 
-      - name: 'Dependencies: restore Qt from cache'
-        id: cache-qt
+      - name: '[unix] Dependencies: restore Qt from cache'
+        id: cache-qt-unix
         uses: actions/cache@v3
         with:
-          path: ../Qt
+          path: ~/work/efibooteditor/Qt
           key: qt-${{ matrix.os }}-${{ matrix.qt_version }}
+        if: ${{ ! startsWith(matrix.os, 'windows') }}
+
+      - name: '[windows] Dependencies: restore Qt from cache'
+        id: cache-qt-windows
+        uses: actions/cache@v3
+        with:
+          path: D:\a\efibooteditor\Qt
+          key: qt-${{ matrix.os }}-${{ matrix.qt_version }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: 'Dependencies: set up Qt environment'
         uses: jurplel/install-qt-action@v2
         with:
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cached: ${{ steps.cache-qt-unix.outputs.cache-hit || steps.cache-qt-windows.outputs.cache-hit }}
           version: ${{ matrix.qt_version }}
           modules: 'qt5compat'
 

--- a/.github/workflows/release_assets.yml
+++ b/.github/workflows/release_assets.yml
@@ -25,17 +25,26 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: 'Dependencies: restore Qt from cache'
-        id: cache-qt
+      - name: '[unix] Dependencies: restore Qt from cache'
+        id: cache-qt-unix
         uses: actions/cache@v3
         with:
-          path: ../Qt
+          path: ~/work/efibooteditor/Qt
           key: qt-${{ matrix.os }}-${{ matrix.qt_version }}
+        if: ${{ ! startsWith(matrix.os, 'windows') }}
+
+      - name: '[windows] Dependencies: restore Qt from cache'
+        id: cache-qt-windows
+        uses: actions/cache@v3
+        with:
+          path: D:\a\efibooteditor\Qt
+          key: qt-${{ matrix.os }}-${{ matrix.qt_version }}
+        if: ${{ startsWith(matrix.os, 'windows') }}
 
       - name: 'Dependencies: set up Qt environment'
         uses: jurplel/install-qt-action@v2
         with:
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+          cached: ${{ steps.cache-qt-unix.outputs.cache-hit || steps.cache-qt-windows.outputs.cache-hit }}
           version: ${{ matrix.qt_version }}
           modules: 'qt5compat'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 
 if(UNIX AND NOT APPLE)
     target_sources(${PROJECT_NAME} PRIVATE
+        src/efivar-lite.linux.c
         src/driveinfo.linux.cpp
     )
 endif()

--- a/include/compat.h
+++ b/include/compat.h
@@ -44,7 +44,7 @@ typedef char TCHAR;
 #define _T
 inline int _tcserror_s(TCHAR *buffer, size_t size, int errnum)
 {
-#ifdef __APPLE__
+#if defined(__APPLE__) || ((_POSIX_C_SOURCE >= 200112L) && !_GNU_SOURCE)
     return strerror_r(errnum, buffer, size);
 #else
     return strerror_r(errnum, buffer, size) == NULL;

--- a/include/efibooteditor.h
+++ b/include/efibooteditor.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include <memory>
 
 #include "bootentrylistmodel.h"
@@ -23,6 +24,7 @@ private:
     BootEntryListModel entries_list_model{};
     std::unique_ptr<QMessageBox> confirmation = nullptr;
     std::unique_ptr<QMessageBox> error = nullptr;
+    std::unique_ptr<QProgressDialog> progress = nullptr;
 
 public:
     explicit EFIBootEditor(QWidget *parent = nullptr);
@@ -54,4 +56,7 @@ private:
     void show_error(const QString &message, const QString &details = "");
     template <class Receiver, typename Slot>
     void show_confirmation(const QString &message, const QMessageBox::StandardButtons &buttons, const QMessageBox::StandardButton &confirmation_button, Receiver confirmation_context, Slot confirmation_slot);
+
+    void show_progress_bar(int step, int total, const QString &details = "");
+    void hide_progress_bar();
 };

--- a/include/efivar-lite/efiboot-loadopt.h
+++ b/include/efivar-lite/efiboot-loadopt.h
@@ -14,6 +14,6 @@ typedef struct efi_load_option_s
 } efi_load_option;
 #pragma pack(pop)
 
-extern efidp efi_loadopt_path(efi_load_option *load_option, ssize_t size_limit) ATTR_NONNULL(1);
-extern uint16_t efi_loadopt_pathlen(efi_load_option *load_option, ssize_t size_limit) ATTR_NONNULL(1) ATTR_VISIBILITY("default");
-extern int efi_loadopt_optional_data(efi_load_option *load_option, size_t load_option_size, uint8_t **optional_data, size_t *optional_data_size) ATTR_NONNULL(1, 3) ATTR_VISIBILITY("default");
+efidp efi_loadopt_path(efi_load_option *load_option, ssize_t size_limit) ATTR_NONNULL(1);
+uint16_t efi_loadopt_pathlen(efi_load_option *load_option, ssize_t size_limit) ATTR_NONNULL(1) ATTR_VISIBILITY("default");
+int efi_loadopt_optional_data(efi_load_option *load_option, size_t load_option_size, uint8_t **optional_data, size_t *optional_data_size) ATTR_NONNULL(1, 3) ATTR_VISIBILITY("default");

--- a/include/efivar-lite/efivar.h
+++ b/include/efivar-lite/efivar.h
@@ -55,13 +55,14 @@ static const mode_t EFI_VARIABLE_MODE_DEFAULTS =
 
 extern const efi_guid_t efi_guid_global;
 
-extern int efi_variables_supported(void);
+int efi_variables_supported(void);
 
-extern int efi_get_variable(efi_guid_t guid, const TCHAR *name, uint8_t **data, size_t *data_size, uint32_t *attributes) ATTR_NONNULL(2, 3, 4, 5);
-extern int efi_del_variable(efi_guid_t guid, const TCHAR *name) ATTR_NONNULL(2);
-extern int efi_set_variable(efi_guid_t guid, const TCHAR *name, uint8_t *data, size_t data_size, uint32_t attributes, mode_t mode) ATTR_NONNULL(2, 3);
-extern int efi_get_next_variable_name(efi_guid_t **guid, TCHAR **name) ATTR_NONNULL(1, 2);
+int efi_get_variable(efi_guid_t guid, const TCHAR *name, uint8_t **data, size_t *data_size, uint32_t *attributes) ATTR_NONNULL(2, 3, 4, 5);
+int efi_del_variable(efi_guid_t guid, const TCHAR *name) ATTR_NONNULL(2);
+int efi_set_variable(efi_guid_t guid, const TCHAR *name, uint8_t *data, size_t data_size, uint32_t attributes, mode_t mode) ATTR_NONNULL(2, 3);
+int efi_get_next_variable_name(efi_guid_t **guid, TCHAR **name) ATTR_NONNULL(1, 2);
+void efi_set_get_next_variable_name_progress_cb(void (*progress_cb)(int, int));
 
-extern int efi_guid_cmp(const efi_guid_t *a, const efi_guid_t *b);
+int efi_guid_cmp(const efi_guid_t *a, const efi_guid_t *b);
 
-extern int efi_error_get(unsigned int n, TCHAR **const filename, TCHAR **const function, int *line, TCHAR **const message, int *error) ATTR_NONNULL(2, 3, 4, 5, 6);
+int efi_error_get(unsigned int n, TCHAR **const filename, TCHAR **const function, int *line, TCHAR **const message, int *error) ATTR_NONNULL(2, 3, 4, 5, 6);

--- a/src/efivar-lite.c
+++ b/src/efivar-lite.c
@@ -54,10 +54,11 @@ static const TCHAR *enumerated_variable_names[] = {
 
 static TCHAR variable_name_buffer[32];
 
-static size_t current_variable = 0;
+const int EFI_MAX_VARIABLES = sizeof(variable_names) / sizeof(variable_names[0]) + sizeof(enumerated_variable_names) / sizeof(enumerated_variable_names[0]) * 65536;
 
 int _efi_get_next_variable_name(efi_guid_t **guid, TCHAR **name)
 {
+    static size_t current_variable = 0;
     *guid = NULL;
     *name = NULL;
     size_t index = current_variable;

--- a/src/efivar-lite.linux.c
+++ b/src/efivar-lite.linux.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+void efi_set_get_next_variable_name_progress_cb(void (*progress_cb)(int, int))
+{
+    (void)progress_cb;
+    // Nothing to do here, efivar doesn't expose progress tracking (and it's not really needed, variables listing is pretty fast)
+}

--- a/src/efivar-lite.win32.c
+++ b/src/efivar-lite.win32.c
@@ -103,15 +103,30 @@ int efi_set_variable(efi_guid_t guid, const TCHAR *name, uint8_t *data, size_t d
     return ret == 0 ? -1 : 0;
 }
 
+static void (*efi_get_next_variable_name_progress_cb)(int, int) = NULL;
+
+void efi_set_get_next_variable_name_progress_cb(void (*progress_cb)(int, int))
+{
+    efi_get_next_variable_name_progress_cb = progress_cb;
+}
+
 int _efi_get_next_variable_name(efi_guid_t **guid, TCHAR **name);
 
 int efi_get_next_variable_name(efi_guid_t **guid, TCHAR **name)
 {
+    extern const int EFI_MAX_VARIABLES;
+    static int current_variable = 0;
     while(1)
     {
+        if(efi_get_next_variable_name_progress_cb)
+            efi_get_next_variable_name_progress_cb(current_variable++, EFI_MAX_VARIABLES);
+
         int ret = _efi_get_next_variable_name(guid, name);
         if(ret <= 0)
+        {
+            current_variable = 0;
             return ret;
+        }
 
         if(GetFirmwareEnvironmentVariable(*name, (*guid)->data, NULL, 0) == 0)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,12 +21,15 @@ auto main(int argc, char *argv[]) -> int
             QStringFromStdTString(*error_message));
     }
 
-    EFIBootEditor w;
-    w.show();
-
     QCommandLineParser parser;
     parser.addHelpOption();
     parser.addVersionOption();
     parser.process(a);
+
+    EFIBootEditor w;
+    w.show();
+
+    QApplication::processEvents();
+    w.resetBootConfiguration();
     return QApplication::exec();
 }


### PR DESCRIPTION
Since Windows/MacOS don't have a way to get a list of available EFI variables (or at least I haven't found it yet?), iterating over all possible ones can take a moment there. Adding simple progress bar to make it more clear that it's not frozen, just in progress on checking ~300k possibilities :stuck_out_tongue: And while I have it, adding it to other possibly slow operations as well.