### PR TITLE
Unify converting numbers to hex format

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '36 10 * * 5'
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+
 jobs:
   build-linux:
     name: ${{ matrix.os }} Qt ${{ matrix.qt_version }} with ${{ matrix.compiler }}

--- a/.github/workflows/release_assets.yml
+++ b/.github/workflows/release_assets.yml
@@ -6,6 +6,9 @@ on:
   release:
     types: [published]
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+
 jobs:
   build-linux:
     name: ${{ matrix.os }} Qt ${{ matrix.qt_version }} with ${{ matrix.compiler }}

--- a/include/compat.h
+++ b/include/compat.h
@@ -120,7 +120,7 @@ inline QString QStringFromStdTString(const std::tstring &string)
 #endif
 }
 
-inline QString toHex(qlonglong number, int min_width = 0, const QString &prefix = "0x")
+inline QString toHex(qulonglong number, int min_width = 0, const QString &prefix = "0x")
 {
     return prefix + QString("%1").arg(number, min_width, HEX_BASE, QChar('0')).toUpper();
 }

--- a/include/compat.h
+++ b/include/compat.h
@@ -89,6 +89,8 @@ inline tstring to_tstring(const Type &value)
 
 }
 
+const int HEX_BASE = 16;
+
 QT_BEGIN_NAMESPACE
 
 inline std::tstring QStringToStdTString(const QString &string)
@@ -118,9 +120,12 @@ inline QString QStringFromStdTString(const std::tstring &string)
 #endif
 }
 
-QT_END_NAMESPACE
+inline QString toHex(qlonglong number, int min_width = 0, const QString &prefix = "0x")
+{
+    return prefix + QString("%1").arg(number, min_width, HEX_BASE, QChar('0')).toUpper();
+}
 
-const int HEX_BASE = 16;
+QT_END_NAMESPACE
 
 inline bool isxnumber(const std::tstring_view &string)
 {

--- a/src/bootentry.cpp
+++ b/src/bootentry.cpp
@@ -294,7 +294,7 @@ auto Device_path::HID::toString(bool refresh) const -> QString
     if(string.size() && !refresh)
         return string;
 
-    return string = QString("Acpi(0x%1, 0x%2)").arg(hid, 0, HEX_BASE).arg(uid, 0, HEX_BASE);
+    return string = QString("Acpi(%1, %2)").arg(toHex(hid), toHex(uid));
 }
 
 static_assert(sizeof(Device_path::Vendor::guid) == sizeof(EFIBoot::Device_path::HWVendor::guid));
@@ -691,8 +691,8 @@ auto Device_path::HD::toJSON() const -> QJsonObject
     QJsonObject hd;
     hd["type"] = TYPE;
     hd["subtype"] = SUBTYPE;
-    hd["partition_start"] = QString("0x%1").arg(partition_start, 0, HEX_BASE);
-    hd["partition_size"] = QString("0x%1").arg(partition_size, 0, HEX_BASE);
+    hd["partition_start"] = toHex(partition_start);
+    hd["partition_size"] = toHex(partition_size);
     hd["partition_number"] = static_cast<int>(partition_number);
     hd["partition_format"] = static_cast<int>(partition_format);
     hd["partition_signature"] = partition_signature.toString();
@@ -705,12 +705,12 @@ auto Device_path::HD::toString(bool refresh) const -> QString
     if(string.size() && !refresh)
         return string;
 
-    QString format = QString("HD(%1, %2, %3. 0x%4, 0x%5)").arg(partition_number);
+    QString format = QString("HD(%1, %2, %3. %4, %5)").arg(partition_number);
     switch(signature_type)
     {
     case EFIBoot::Device_path::SIGNATURE::MBR:
     {
-        format = format.arg("MBR", QString("0x%1").arg(partition_signature.data1, 0, HEX_BASE));
+        format = format.arg("MBR", toHex(partition_signature.data1));
         break;
     }
 
@@ -723,7 +723,7 @@ auto Device_path::HD::toString(bool refresh) const -> QString
         break;
     }
 
-    return string = format.arg(partition_start, 0, HEX_BASE).arg(partition_size, 0, HEX_BASE);
+    return string = format.arg(toHex(partition_start), toHex(partition_size));
 }
 
 Device_path::File::File(const EFIBoot::Device_path::File &file)
@@ -926,7 +926,7 @@ auto Device_path::Unknown::toString(bool refresh) const -> QString
     if(string.size() && !refresh)
         return string;
 
-    return string = QString("Unknown(0x%1, 0x%2, [%3B])").arg(type, 0, HEX_BASE).arg(subtype, 0, HEX_BASE).arg(data.size());
+    return string = QString("Unknown(%1, %2, [%3B])").arg(toHex(type), toHex(subtype)).arg(data.size());
 }
 
 #undef try_read_3

--- a/src/bootentryform.cpp
+++ b/src/bootentryform.cpp
@@ -29,7 +29,7 @@ void BootEntryForm::setItem(const QModelIndex &index, const BootEntry *item)
 
     setDisabled(true);
 
-    ui->index_text->setText(QString("0x%1").arg(item ? item->index : 0, 4, HEX_BASE, QChar('0')));
+    ui->index_text->setText(toHex(item ? item->index : 0, 4));
     ui->description_text->setText(item ? item->description : "");
     paths_proxy_list_model.setBootEntryItem(index, item);
     ui->optional_data_text->setPlainText(item ? item->optional_data : "");

--- a/src/bootentryform.cpp
+++ b/src/bootentryform.cpp
@@ -29,7 +29,7 @@ void BootEntryForm::setItem(const QModelIndex &index, const BootEntry *item)
 
     setDisabled(true);
 
-    ui->index_text->setText(toHex(item ? item->index : 0, 4));
+    ui->index_text->setText(toHex(item ? item->index : 0u, 4));
     ui->description_text->setText(item ? item->description : "");
     paths_proxy_list_model.setBootEntryItem(index, item);
     ui->optional_data_text->setPlainText(item ? item->optional_data : "");

--- a/src/bootentrywidget.cpp
+++ b/src/bootentrywidget.cpp
@@ -17,7 +17,7 @@ BootEntryWidget::~BootEntryWidget()
 
 void BootEntryWidget::set_index(const quint32 index)
 {
-    ui->index->setText(QString("%1").arg(index, 4, HEX_BASE, QChar('0')).toUpper());
+    ui->index->setText(toHex(index, 4));
 }
 
 void BootEntryWidget::set_description(const QString &description)

--- a/src/devicepathdialog.cpp
+++ b/src/devicepathdialog.cpp
@@ -208,8 +208,8 @@ void DevicePathDialog::setPCIForm(const Device_path::PCI &pci)
 void DevicePathDialog::setHIDForm(const Device_path::HID &hid)
 {
     ui->options->setCurrentIndex(FormIndex::HID);
-    ui->hid_text->setText(QString::number(hid.hid, HEX_BASE));
-    ui->uid_text->setText(QString::number(hid.uid, HEX_BASE));
+    ui->hid_text->setText(toHex(hid.hid));
+    ui->uid_text->setText(toHex(hid.uid));
 }
 
 void DevicePathDialog::setVendorForm(const Device_path::Vendor &vendor)
@@ -316,8 +316,8 @@ void DevicePathDialog::setHDForm(const Device_path::HD &hd)
         ui->signature_text->setText(hd.partition_signature.toString());
 
     ui->partition_number->setValue(static_cast<int>(hd.partition_number));
-    ui->start_text->setText(QString::number(hd.partition_start, HEX_BASE));
-    ui->size_text->setText(QString::number(hd.partition_size, HEX_BASE));
+    ui->start_text->setText(toHex(hd.partition_start));
+    ui->size_text->setText(toHex(hd.partition_size));
 }
 
 void DevicePathDialog::setFileForm(const Device_path::File &file)
@@ -347,8 +347,8 @@ void DevicePathDialog::setEndForm(const EFIBoot::EFIDP_END subtype)
 void DevicePathDialog::setUnknownForm(const Device_path::Unknown &unknown)
 {
     ui->options->setCurrentIndex(FormIndex::Unknown_);
-    ui->unknown_type_text->setText(QString::number(unknown.type, HEX_BASE));
-    ui->unknown_subtype_text->setText(QString::number(unknown.subtype, HEX_BASE));
+    ui->unknown_type_text->setText(toHex(unknown.type));
+    ui->unknown_subtype_text->setText(toHex(unknown.subtype));
     ui->unknown_data_format_combo->setCurrentIndex(UnknownDataFormat::Base64);
     unknown_data_format_combo_index = 0;
     ui->unknown_data_text->setPlainText(unknown.data.toBase64());
@@ -417,8 +417,8 @@ void DevicePathDialog::diskChoiceChanged(int index)
         ui->signature_text->setText(driveinfo.signature.toString());
 
     ui->partition_number->setValue(static_cast<int>(driveinfo.partition));
-    ui->start_text->setText(QString::number(driveinfo.start, HEX_BASE));
-    ui->size_text->setText(QString::number(driveinfo.size, HEX_BASE));
+    ui->start_text->setText(toHex(driveinfo.start));
+    ui->size_text->setText(toHex(driveinfo.size));
 }
 
 void DevicePathDialog::signatureTypeChoiceChanged(int index)

--- a/src/efibooteditor.cpp
+++ b/src/efibooteditor.cpp
@@ -127,7 +127,7 @@ void EFIBootEditor::resetBootConfiguration()
     entries_list_model.clear();
     for(const auto &index: order)
     {
-        auto qname = QString("Boot%1").arg(index, 4, HEX_BASE, QChar('0'));
+        auto qname = toHex(index, 4, "Boot");
         auto name = QStringToStdTString(qname);
         show_progress_bar(step++, total_steps, tr("Processing EFI Boot Manager entries (%1)...").arg(qname));
         auto variable = EFIBoot::get_variable<EFIBoot::Load_option>(name_to_guid[name], name);
@@ -205,7 +205,7 @@ void EFIBootEditor::saveBootConfiguration()
     QSet<quint16> saved;
     for(const auto &entry: entries_list_model.getEntries())
     {
-        auto qname = QString("Boot%1").arg(entry.index, 4, HEX_BASE, QChar('0'));
+        auto qname = toHex(entry.index, 4, "Boot");
         if(saved.contains(entry.index))
             return show_error(tr("Error saving entries!"), tr("Entry %1(%2): Duplicated index!").arg(qname, entry.description));
 
@@ -359,7 +359,7 @@ void EFIBootEditor::importJSONEFIData(const QJsonObject &input)
     entries_list_model.clear();
     for(const auto &index: order)
     {
-        auto name = QString("%1").arg(index, 4, HEX_BASE, QChar('0'));
+        auto name = toHex(index, 4, "");
         show_progress_bar(step++, total_steps, tr("Importing EFI Boot Manager entries (Boot%1)...").arg(name));
         auto entry = BootEntry::fromJSON(boot[name].toObject());
         if(!entry)
@@ -466,7 +466,7 @@ void EFIBootEditor::importRawEFIData(const QJsonObject &input)
     entries_list_model.clear();
     for(const auto &index: order)
     {
-        auto name = QString("%1").arg(index, 4, HEX_BASE, QChar('0'));
+        auto name = toHex(index, 4, "");
         show_progress_bar(step++, total_steps, tr("Importing EFI Boot Manager entries (Boot%1)...").arg(name));
         if(!boot[name].isObject())
             return show_error(tr("Error importing boot configuration!"), tr("Couldn't parse Boot/%1: object expected").arg(name));
@@ -515,7 +515,7 @@ void EFIBootEditor::exportBootConfiguration(const QString &file_name)
     QSet<quint16> saved;
     for(const auto &entry: entries_list_model.getEntries())
     {
-        auto name = QString("%1").arg(entry.index, 4, HEX_BASE, QChar('0'));
+        auto name = toHex(entry.index, 4, "");
         if(saved.contains(entry.index))
             return show_error(tr("Error saving entries!"), tr("Entry %1(%2): Duplicated index!").arg(name, entry.description));
 

--- a/src/efivar-lite.common.h
+++ b/src/efivar-lite.common.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/form/devicepathdialog.ui
+++ b/src/form/devicepathdialog.ui
@@ -207,7 +207,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;HID in hexadecimal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;\0\xhhhhhhhh;_</string>
+          <string>&lt;\0\xHHHHHHHH;_</string>
          </property>
         </widget>
        </item>
@@ -239,7 +239,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;UID in hexadecimal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;\0\xhhhhhhhh;_</string>
+          <string>&lt;\0\xHHHHHHHH;_</string>
          </property>
         </widget>
        </item>
@@ -446,7 +446,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;MAC address&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;hh:hh:hh:hh:hh:hh:hh:hh:hh:hh:hh:hh:hh:hh:hh:hh;_</string>
+          <string>&lt;HH:HH:HH:HH:HH:HH:HH:HH:HH:HH:HH:HH:HH:HH:HH:HH;_</string>
          </property>
         </widget>
        </item>
@@ -940,7 +940,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Local IP address&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh</string>
+          <string>&lt;HHHH:HHHH:HHHH:HHHH:HHHH:HHHH:HHHH:HHHH</string>
          </property>
         </widget>
        </item>
@@ -975,7 +975,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remote IP address&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh</string>
+          <string>&lt;HHHH:HHHH:HHHH:HHHH:HHHH:HHHH:HHHH:HHHH</string>
          </property>
         </widget>
        </item>
@@ -1063,7 +1063,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gateway IP address&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh:hhhh</string>
+          <string>&lt;HHHH:HHHH:HHHH:HHHH:HHHH:HHHH:HHHH:HHHH</string>
          </property>
         </widget>
        </item>
@@ -1464,7 +1464,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Partition start offset in hexadecimal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;\0\xhhhhhhhhhhhhhhhh;_</string>
+          <string>&lt;\0\xHHHHHHHHHHHHHHHH;_</string>
          </property>
          <property name="text">
           <string>0x0000000000000000</string>
@@ -1499,7 +1499,7 @@
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Partition size in hexadecimal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="inputMask">
-          <string>&lt;\0\xhhhhhhhhhhhhhhhh;_</string>
+          <string>&lt;\0\xHHHHHHHHHHHHHHHH;_</string>
          </property>
         </widget>
        </item>
@@ -1808,14 +1808,14 @@
        <item row="0" column="1">
         <widget class="QLineEdit" name="unknown_type_text">
          <property name="inputMask">
-          <string>&lt;\0\xhh;_</string>
+          <string>&lt;\0\xHH;_</string>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
         <widget class="QLineEdit" name="unknown_subtype_text">
          <property name="inputMask">
-          <string>&lt;\0\xhh;_</string>
+          <string>&lt;\0\xHH;_</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
UEFI uses uppercase for hexadecimal numbers everywhere (specifically in Boot entries names...) but QString hex formatting is lowercase by default. This resulted in errors loading entries with indexes higher than 9.

Switching all hex number formatting to simple helper function to make sure they're always uppercase everywhere instead of random `QString::number` and `QString::arg` formatting scattered across the codebase.

Should fix: https://github.com/Neverous/efibooteditor/issues/30