### PR TITLE
efivar-lite: fix case of hex strings when enumerating efi variables

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -68,6 +68,10 @@ jobs:
         run: sudo apt-get install libefiboot1 libefiboot-dev libefivar-dev
         shell: bash
 
+      - name: Install libxkbcommon-x11-0
+        run: sudo apt-get install libxkbcommon-x11-0
+        shell: bash
+
       - name: Create build directory
         run: mkdir -p build/debug
 

--- a/.github/workflows/release_assets.yml
+++ b/.github/workflows/release_assets.yml
@@ -61,6 +61,10 @@ jobs:
         run: sudo apt-get install libefiboot1 libefiboot-dev libefivar-dev
         shell: bash
 
+      - name: Install libxkbcommon-x11-0
+        run: sudo apt-get install libxkbcommon-x11-0
+        shell: bash
+
       - name: Create build directory
         run: mkdir -p build/release
 

--- a/src/efivar-lite.c
+++ b/src/efivar-lite.c
@@ -77,7 +77,7 @@ int _efi_get_next_variable_name(efi_guid_t **guid, TCHAR **name)
         size_t enum_index = index / 65536u;
         size_t enum_value = index - enum_index * 65536u;
         *guid = (efi_guid_t *)&efi_guid_global;
-        _sntprintf_s(variable_name_buffer, 32, 31, _T("%s%04zx"), enumerated_variable_names[enum_index], enum_value);
+        _sntprintf_s(variable_name_buffer, 32, 31, _T("%s%04zX"), enumerated_variable_names[enum_index], enum_value);
         *name = (TCHAR *)&variable_name_buffer;
         ++current_variable;
         return 1;


### PR DESCRIPTION
Missed the manual enumeration (used on Windows and macOS) in #31 