### PR TITLE
Add placeholders for "broken" boot entries

### DIFF
--- a/include/bootentry.h
+++ b/include/bootentry.h
@@ -502,6 +502,8 @@ public:
 
     bool is_current_boot = false;
     bool is_next_boot = false;
+    bool is_error = false;
+    QString error = "";
 
     OptionalDataFormat optional_data_format = OptionalDataFormat::Base64;
 
@@ -510,6 +512,7 @@ private:
 
 public:
     static BootEntry fromEFIBootLoadOption(const EFIBoot::Load_option &load_option);
+    static BootEntry fromError(const QString &error);
     EFIBoot::Load_option toEFIBootLoadOption() const;
 
     static std::optional<BootEntry> fromJSON(const QJsonObject &obj);

--- a/include/bootentrywidget.h
+++ b/include/bootentrywidget.h
@@ -27,6 +27,7 @@ public:
 
     void setReadOnly(bool readonly);
     void showBootOptions(bool is_boot);
+    void showDevicePath(bool not_error);
 
     void setIndex(const uint32_t index);
     void setDescription(const QString &description);

--- a/include/efiboot.h
+++ b/include/efiboot.h
@@ -26,6 +26,11 @@ inline bool operator==(const efi_guid_t &first, const efi_guid_t &second)
     return efi_guid_cmp(&first, &second) == 0;
 }
 
+inline bool operator!=(const efi_guid_t &first, const efi_guid_t &second)
+{
+    return efi_guid_cmp(&first, &second) != 0;
+}
+
 typedef std::vector<uint8_t> Raw_data;
 
 template <class Type = Raw_data>

--- a/src/bootentry.cpp
+++ b/src/bootentry.cpp
@@ -51,8 +51,20 @@ auto BootEntry::fromEFIBootLoadOption(
     return value;
 }
 
+auto BootEntry::fromError(const QString &error) -> BootEntry
+{
+    BootEntry value;
+    value.is_error = true;
+    value.description = "Error";
+    value.error = error;
+    return value;
+}
+
 auto BootEntry::toEFIBootLoadOption() const -> EFIBoot::Load_option
 {
+    if(is_error)
+        return {};
+
     EFIBoot::Load_option load_option;
     load_option.description = description.toStdU16String();
     {
@@ -96,6 +108,9 @@ auto BootEntry::fromJSON(const QJsonObject &obj) -> std::optional<BootEntry>
 
 auto BootEntry::toJSON() const -> QJsonObject
 {
+    if(is_error)
+        return {};
+
     QJsonObject load_option;
     load_option["description"] = description;
     load_option["optional_data_format"] = static_cast<int>(optional_data_format);

--- a/src/bootentrydelegate.cpp
+++ b/src/bootentrydelegate.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "bootentrydelegate.h"
+
 #include "bootentry.h"
 #include "bootentrylistmodel.h"
 
@@ -17,7 +18,8 @@ void BootEntryDelegate::setupWidgetFromItem(Widget &widget, const Item &item) co
     widget.setReadOnly(options & BootEntryListModel::ReadOnly);
     widget.setIndex(item->index);
     widget.setDescription(item->description);
-    widget.setData(item->optional_data);
+    widget.setData(!item->is_error ? item->optional_data : item->error);
+    widget.showDevicePath(!item->is_error);
     widget.setDevicePath(item->formatDevicePath(false));
     widget.showBootOptions(options & BootEntryListModel::IsBoot);
     widget.setCurrentBoot(item->is_current_boot);

--- a/src/bootentryform.cpp
+++ b/src/bootentryform.cpp
@@ -36,6 +36,7 @@ void BootEntryForm::setReadOnly(bool readonly)
     ui->device_path->setReadOnly(readonly);
     ui->device_path_actions->setDisabled(readonly);
     ui->optional_data_format_combo->setDisabled(false);
+    ui->error_text->setDisabled(readonly);
 }
 
 void BootEntryForm::setBootEntryListModel(BootEntryListModel &model)
@@ -60,6 +61,11 @@ void BootEntryForm::setItem(const QModelIndex &index, const BootEntry *item)
     ui->attribute_hidden->setChecked(item && (item->attributes & EFIBoot::Load_option_attribute::HIDDEN) == EFIBoot::Load_option_attribute::HIDDEN);
     ui->attribute_force_reconnect->setChecked(item && (item->attributes & EFIBoot::Load_option_attribute::FORCE_RECONNECT) == EFIBoot::Load_option_attribute::FORCE_RECONNECT);
     ui->category_combo->setCurrentIndex(item && (item->attributes & EFIBoot::Load_option_attribute::CATEGORY_APP) == EFIBoot::Load_option_attribute::CATEGORY_APP);
+    ui->error_text->setText(item ? item->error : "");
+
+    ui->form_fields->setVisible(item ? !item->is_error : true);
+    ui->error_text->setVisible(item ? item->is_error : false);
+    ui->error_note->setVisible(item ? item->is_error : false);
 
     setDisabled(!item);
 }

--- a/src/bootentrywidget.cpp
+++ b/src/bootentrywidget.cpp
@@ -28,6 +28,11 @@ void BootEntryWidget::showBootOptions(bool is_boot)
     ui->next_boot->setVisible(is_boot);
 }
 
+void BootEntryWidget::showDevicePath(bool not_error)
+{
+    ui->device_path->setVisible(not_error);
+}
+
 void BootEntryWidget::setIndex(const uint32_t index)
 {
     ui->index->setText(toHex(index, 4));

--- a/src/form/bootentryform.ui
+++ b/src/form/bootentryform.ui
@@ -5,13 +5,7 @@
   <property name="windowTitle">
    <string>Boot entry form</string>
   </property>
-  <layout class="QFormLayout" name="form_layout">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::ExpandingFieldsGrow</enum>
-   </property>
-   <property name="labelAlignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -24,520 +18,567 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QLabel" name="index_label">
+   <item>
+    <widget class="QLabel" name="error_text">
      <property name="toolTip">
-      <string>Index</string>
+      <string>Error</string>
      </property>
      <property name="statusTip">
-      <string>Index</string>
+      <string>Error</string>
      </property>
      <property name="text">
-      <string>Index</string>
+      <string notr="true"/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="index_text">
-     <property name="font">
-      <font>
-       <family>Monospace</family>
-      </font>
-     </property>
+   <item>
+    <widget class="QLabel" name="error_note">
      <property name="toolTip">
-      <string>Index</string>
+      <string>Error note</string>
      </property>
      <property name="statusTip">
-      <string>Index</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="inputMask">
-      <string notr="true">&gt;\0\xHHHH;_</string>
+      <string>Error note</string>
      </property>
      <property name="text">
-      <string notr="true">0x</string>
+      <string>This entry placeholder is shown here to indicate it's referenced in boot order. It won't be modified on save, just left as is.</string>
      </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="description_label">
-     <property name="toolTip">
-      <string>Description</string>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
-     <property name="statusTip">
-      <string>Description</string>
-     </property>
-     <property name="text">
-      <string>Description</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="description_text">
-     <property name="toolTip">
-      <string>Description</string>
-     </property>
-     <property name="statusTip">
-      <string>Description</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="inputMethodHints">
-      <set>Qt::ImhLatinOnly|Qt::ImhNoPredictiveText</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="path_label">
-     <property name="toolTip">
-      <string>Path</string>
-     </property>
-     <property name="statusTip">
-      <string>Path</string>
-     </property>
-     <property name="text">
-      <string>Path</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="DevicePathView" name="device_path">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <family>Monospace</family>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Device path</string>
-     </property>
-     <property name="statusTip">
-      <string>Device path</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::AdjustToContents</enum>
-     </property>
-     <property name="alternatingRowColors">
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
-     <property name="horizontalScrollMode">
-      <enum>QAbstractItemView::ScrollPerPixel</enum>
-     </property>
-     <property name="movement">
-      <enum>QListView::Snap</enum>
-     </property>
-     <property name="resizeMode">
-      <enum>QListView::Adjust</enum>
-     </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QWidget" name="device_path_actions" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QHBoxLayout" name="paths_actions_layout" stretch="0,0,0,0,0,1">
-      <property name="spacing">
-       <number>1</number>
+   <item>
+    <widget class="QWidget" name="form_fields" native="true">
+     <layout class="QFormLayout" name="form_fields_layout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::ExpandingFieldsGrow</enum>
       </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>1</number>
-      </property>
-      <property name="bottomMargin">
-       <number>1</number>
-      </property>
-      <item>
-       <widget class="QPushButton" name="path_move_up">
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Move file path up</string>
-        </property>
-        <property name="statusTip">
-         <string>Move file path up</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset theme="up">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="path_move_down">
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Move file path down</string>
-        </property>
-        <property name="statusTip">
-         <string>Move file path down</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset theme="down">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="path_remove">
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Remove file path</string>
-        </property>
-        <property name="statusTip">
-         <string>Remove file path</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset theme="remove">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="path_edit">
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Edit file path</string>
-        </property>
-        <property name="statusTip">
-         <string>Edit file path</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset theme="edit">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="path_add">
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Add file path</string>
-        </property>
-        <property name="statusTip">
-         <string>Add file path</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset theme="add">
-          <normaloff>.</normaloff>.</iconset>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="paths_actions_spacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="optional_data_label">
-     <property name="toolTip">
-      <string>Optional data</string>
-     </property>
-     <property name="statusTip">
-      <string>Optional data</string>
-     </property>
-     <property name="text">
-      <string>Optional</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="optional_data_format_combo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Optional data format</string>
-     </property>
-     <property name="statusTip">
-      <string>Optional data format</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <item>
-      <property name="text">
-       <string>BASE64</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>UTF-16</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>UTF-8</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>HEX</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPlainTextEdit" name="optional_data_text">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="font">
-      <font>
-       <family>Monospace</family>
-      </font>
-     </property>
-     <property name="toolTip">
-      <string>Optional data</string>
-     </property>
-     <property name="statusTip">
-      <string>Optional data</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::AdjustToContents</enum>
-     </property>
-     <property name="undoRedoEnabled">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="attributes_label">
-     <property name="toolTip">
-      <string>Attributes</string>
-     </property>
-     <property name="statusTip">
-      <string>Attributes</string>
-     </property>
-     <property name="text">
-      <string>Attributes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QWidget" name="attributes_box" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QGridLayout" name="attributes_box_layout" columnstretch="0,0,0,1">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <property name="spacing">
-       <number>9</number>
+      <property name="labelAlignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
       <item row="0" column="0">
-       <widget class="QCheckBox" name="attribute_active">
+       <widget class="QLabel" name="index_label">
         <property name="toolTip">
-         <string>Active</string>
+         <string>Index</string>
         </property>
         <property name="statusTip">
-         <string>Active</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>Index</string>
         </property>
         <property name="text">
-         <string>Active</string>
+         <string>Index</string>
         </property>
        </widget>
-      </item>
-      <item row="0" column="3">
-       <spacer name="attribute_box_spacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item row="0" column="1">
-       <widget class="QCheckBox" name="attribute_hidden">
+       <widget class="QLineEdit" name="index_text">
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+         </font>
+        </property>
         <property name="toolTip">
-         <string>Hidden</string>
+         <string>Index</string>
         </property>
         <property name="statusTip">
-         <string>Hidden</string>
+         <string>Index</string>
         </property>
         <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="inputMask">
+         <string notr="true">&gt;\0\xHHHH;_</string>
         </property>
         <property name="text">
-         <string>Hidden</string>
+         <string notr="true">0x</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QCheckBox" name="attribute_force_reconnect">
+      <item row="1" column="0">
+       <widget class="QLabel" name="description_label">
         <property name="toolTip">
-         <string>Force reconnect</string>
+         <string>Description</string>
         </property>
         <property name="statusTip">
-         <string>Force reconnect</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>Description</string>
         </property>
         <property name="text">
-         <string>Force reconnect</string>
+         <string>Description</string>
         </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="description_text">
+        <property name="toolTip">
+         <string>Description</string>
+        </property>
+        <property name="statusTip">
+         <string>Description</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="inputMethodHints">
+         <set>Qt::ImhLatinOnly|Qt::ImhNoPredictiveText</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="path_label">
+        <property name="toolTip">
+         <string>Path</string>
+        </property>
+        <property name="statusTip">
+         <string>Path</string>
+        </property>
+        <property name="text">
+         <string>Path</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="DevicePathView" name="device_path">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>Device path</string>
+        </property>
+        <property name="statusTip">
+         <string>Device path</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="horizontalScrollMode">
+         <enum>QAbstractItemView::ScrollPerPixel</enum>
+        </property>
+        <property name="movement">
+         <enum>QListView::Snap</enum>
+        </property>
+        <property name="resizeMode">
+         <enum>QListView::Adjust</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QWidget" name="device_path_actions" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QHBoxLayout" name="paths_actions_layout" stretch="0,0,0,0,0,1">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>1</number>
+         </property>
+         <property name="bottomMargin">
+          <number>1</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="path_move_up">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Move file path up</string>
+           </property>
+           <property name="statusTip">
+            <string>Move file path up</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset theme="up">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="path_move_down">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Move file path down</string>
+           </property>
+           <property name="statusTip">
+            <string>Move file path down</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset theme="down">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="path_remove">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Remove file path</string>
+           </property>
+           <property name="statusTip">
+            <string>Remove file path</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset theme="remove">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="path_edit">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Edit file path</string>
+           </property>
+           <property name="statusTip">
+            <string>Edit file path</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset theme="edit">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="path_add">
+           <property name="maximumSize">
+            <size>
+             <width>40</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>Add file path</string>
+           </property>
+           <property name="statusTip">
+            <string>Add file path</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset theme="add">
+             <normaloff>.</normaloff>.</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="paths_actions_spacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="optional_data_label">
+        <property name="toolTip">
+         <string>Optional data</string>
+        </property>
+        <property name="statusTip">
+         <string>Optional data</string>
+        </property>
+        <property name="text">
+         <string>Optional</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="optional_data_format_combo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Optional data format</string>
+        </property>
+        <property name="statusTip">
+         <string>Optional data format</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>BASE64</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>UTF-16</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>UTF-8</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>HEX</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QPlainTextEdit" name="optional_data_text">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <family>Monospace</family>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>Optional data</string>
+        </property>
+        <property name="statusTip">
+         <string>Optional data</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContents</enum>
+        </property>
+        <property name="undoRedoEnabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="attributes_label">
+        <property name="toolTip">
+         <string>Attributes</string>
+        </property>
+        <property name="statusTip">
+         <string>Attributes</string>
+        </property>
+        <property name="text">
+         <string>Attributes</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QWidget" name="attributes_box" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QGridLayout" name="attributes_box_layout" columnstretch="0,0,0,1">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>9</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QCheckBox" name="attribute_active">
+           <property name="toolTip">
+            <string>Active</string>
+           </property>
+           <property name="statusTip">
+            <string>Active</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Active</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <spacer name="attribute_box_spacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="attribute_hidden">
+           <property name="toolTip">
+            <string>Hidden</string>
+           </property>
+           <property name="statusTip">
+            <string>Hidden</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Hidden</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QCheckBox" name="attribute_force_reconnect">
+           <property name="toolTip">
+            <string>Force reconnect</string>
+           </property>
+           <property name="statusTip">
+            <string>Force reconnect</string>
+           </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Force reconnect</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="category_label">
+        <property name="toolTip">
+         <string>Category</string>
+        </property>
+        <property name="statusTip">
+         <string>Category</string>
+        </property>
+        <property name="text">
+         <string>Category</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QComboBox" name="category_combo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Category</string>
+        </property>
+        <property name="statusTip">
+         <string>Category</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Boot</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>App</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="category_label">
-     <property name="toolTip">
-      <string>Category</string>
-     </property>
-     <property name="statusTip">
-      <string>Category</string>
-     </property>
-     <property name="text">
-      <string>Category</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QComboBox" name="category_combo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Category</string>
-     </property>
-     <property name="statusTip">
-      <string>Category</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <item>
-      <property name="text">
-       <string>Boot</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>App</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="8" column="1">
+   <item>
     <spacer name="vertical_spacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/translations/efibooteditor_en.ts
+++ b/translations/efibooteditor_en.ts
@@ -4,37 +4,37 @@
 <context>
     <name>BootEntryForm</name>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="67"/>
-        <location filename="../src/form/bootentryform.ui" line="70"/>
-        <location filename="../src/form/bootentryform.ui" line="73"/>
-        <location filename="../src/form/bootentryform.ui" line="80"/>
-        <location filename="../src/form/bootentryform.ui" line="83"/>
+        <location filename="../src/form/bootentryform.ui" line="105"/>
+        <location filename="../src/form/bootentryform.ui" line="108"/>
+        <location filename="../src/form/bootentryform.ui" line="111"/>
+        <location filename="../src/form/bootentryform.ui" line="118"/>
+        <location filename="../src/form/bootentryform.ui" line="121"/>
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="96"/>
-        <location filename="../src/form/bootentryform.ui" line="99"/>
-        <location filename="../src/form/bootentryform.ui" line="102"/>
+        <location filename="../src/form/bootentryform.ui" line="134"/>
+        <location filename="../src/form/bootentryform.ui" line="137"/>
+        <location filename="../src/form/bootentryform.ui" line="140"/>
         <source>Path</source>
         <translation>Path</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="318"/>
-        <location filename="../src/form/bootentryform.ui" line="321"/>
-        <location filename="../src/form/bootentryform.ui" line="381"/>
-        <location filename="../src/form/bootentryform.ui" line="384"/>
+        <location filename="../src/form/bootentryform.ui" line="356"/>
+        <location filename="../src/form/bootentryform.ui" line="359"/>
+        <location filename="../src/form/bootentryform.ui" line="419"/>
+        <location filename="../src/form/bootentryform.ui" line="422"/>
         <source>Optional data</source>
         <translation>Optional data</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="324"/>
+        <location filename="../src/form/bootentryform.ui" line="362"/>
         <source>Optional</source>
         <translation>Optional</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="337"/>
-        <location filename="../src/form/bootentryform.ui" line="340"/>
+        <location filename="../src/form/bootentryform.ui" line="375"/>
+        <location filename="../src/form/bootentryform.ui" line="378"/>
         <source>Optional data format</source>
         <translation>Optional data format</translation>
     </message>
@@ -44,189 +44,206 @@
         <translation>Boot entry form</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="24"/>
+        <location filename="../src/form/bootentryform.ui" line="27"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="40"/>
+        <location filename="../src/form/bootentryform.ui" line="43"/>
+        <source>Error note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="46"/>
+        <source>This entry placeholder is shown here to indicate it&apos;s referenced in boot order. It won&apos;t be modified on save, just left as is.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="120"/>
-        <location filename="../src/form/bootentryform.ui" line="123"/>
+        <location filename="../src/form/bootentryform.ui" line="158"/>
+        <location filename="../src/form/bootentryform.ui" line="161"/>
         <source>Device path</source>
         <translation>Device path</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="126"/>
+        <location filename="../src/form/bootentryform.ui" line="164"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="178"/>
-        <location filename="../src/form/bootentryform.ui" line="181"/>
+        <location filename="../src/form/bootentryform.ui" line="216"/>
+        <location filename="../src/form/bootentryform.ui" line="219"/>
         <source>Move file path up</source>
         <translation>Move file path up</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="184"/>
+        <location filename="../src/form/bootentryform.ui" line="222"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="204"/>
-        <location filename="../src/form/bootentryform.ui" line="207"/>
+        <location filename="../src/form/bootentryform.ui" line="242"/>
+        <location filename="../src/form/bootentryform.ui" line="245"/>
         <source>Move file path down</source>
         <translation>Move file path down</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="210"/>
+        <location filename="../src/form/bootentryform.ui" line="248"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="230"/>
-        <location filename="../src/form/bootentryform.ui" line="233"/>
+        <location filename="../src/form/bootentryform.ui" line="268"/>
+        <location filename="../src/form/bootentryform.ui" line="271"/>
         <source>Remove file path</source>
         <translation>Remove file path</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="236"/>
+        <location filename="../src/form/bootentryform.ui" line="274"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="256"/>
-        <location filename="../src/form/bootentryform.ui" line="259"/>
+        <location filename="../src/form/bootentryform.ui" line="294"/>
+        <location filename="../src/form/bootentryform.ui" line="297"/>
         <source>Edit file path</source>
         <translation>Edit file path</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="262"/>
+        <location filename="../src/form/bootentryform.ui" line="300"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="282"/>
-        <location filename="../src/form/bootentryform.ui" line="285"/>
+        <location filename="../src/form/bootentryform.ui" line="320"/>
+        <location filename="../src/form/bootentryform.ui" line="323"/>
         <source>Add file path</source>
         <translation>Add file path</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="288"/>
+        <location filename="../src/form/bootentryform.ui" line="326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="343"/>
+        <location filename="../src/form/bootentryform.ui" line="381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="347"/>
+        <location filename="../src/form/bootentryform.ui" line="385"/>
         <source>BASE64</source>
         <translation>BASE64</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="352"/>
+        <location filename="../src/form/bootentryform.ui" line="390"/>
         <source>UTF-16</source>
         <translation>UTF-16</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="357"/>
+        <location filename="../src/form/bootentryform.ui" line="395"/>
         <source>UTF-8</source>
         <translation>UTF-8</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="362"/>
+        <location filename="../src/form/bootentryform.ui" line="400"/>
         <source>HEX</source>
         <translation>HEX</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="387"/>
+        <location filename="../src/form/bootentryform.ui" line="425"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="400"/>
-        <location filename="../src/form/bootentryform.ui" line="403"/>
-        <location filename="../src/form/bootentryform.ui" line="406"/>
+        <location filename="../src/form/bootentryform.ui" line="438"/>
+        <location filename="../src/form/bootentryform.ui" line="441"/>
+        <location filename="../src/form/bootentryform.ui" line="444"/>
         <source>Attributes</source>
         <translation>Attributes</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="526"/>
+        <location filename="../src/form/bootentryform.ui" line="564"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="54"/>
+        <location filename="../src/form/bootentryform.ui" line="92"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="443"/>
+        <location filename="../src/form/bootentryform.ui" line="481"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="472"/>
+        <location filename="../src/form/bootentryform.ui" line="510"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="488"/>
+        <location filename="../src/form/bootentryform.ui" line="526"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="437"/>
-        <location filename="../src/form/bootentryform.ui" line="440"/>
-        <location filename="../src/form/bootentryform.ui" line="446"/>
+        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="478"/>
+        <location filename="../src/form/bootentryform.ui" line="484"/>
         <source>Active</source>
         <translation>Active</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="482"/>
-        <location filename="../src/form/bootentryform.ui" line="485"/>
-        <location filename="../src/form/bootentryform.ui" line="491"/>
+        <location filename="../src/form/bootentryform.ui" line="520"/>
+        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="529"/>
         <source>Force reconnect</source>
         <translation>Force reconnect</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="466"/>
-        <location filename="../src/form/bootentryform.ui" line="469"/>
-        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="504"/>
+        <location filename="../src/form/bootentryform.ui" line="507"/>
+        <location filename="../src/form/bootentryform.ui" line="513"/>
         <source>Hidden</source>
         <translation>Hidden</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="501"/>
-        <location filename="../src/form/bootentryform.ui" line="504"/>
-        <location filename="../src/form/bootentryform.ui" line="507"/>
-        <location filename="../src/form/bootentryform.ui" line="520"/>
-        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="539"/>
+        <location filename="../src/form/bootentryform.ui" line="542"/>
+        <location filename="../src/form/bootentryform.ui" line="545"/>
+        <location filename="../src/form/bootentryform.ui" line="558"/>
+        <location filename="../src/form/bootentryform.ui" line="561"/>
         <source>Category</source>
         <translation>Category</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="530"/>
+        <location filename="../src/form/bootentryform.ui" line="568"/>
         <source>Boot</source>
         <translation>Boot</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="535"/>
+        <location filename="../src/form/bootentryform.ui" line="573"/>
         <source>App</source>
         <translation>App</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="30"/>
-        <location filename="../src/form/bootentryform.ui" line="33"/>
-        <location filename="../src/form/bootentryform.ui" line="36"/>
-        <location filename="../src/form/bootentryform.ui" line="48"/>
-        <location filename="../src/form/bootentryform.ui" line="51"/>
+        <location filename="../src/form/bootentryform.ui" line="68"/>
+        <location filename="../src/form/bootentryform.ui" line="71"/>
+        <location filename="../src/form/bootentryform.ui" line="74"/>
+        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="89"/>
         <source>Index</source>
         <translation>Index</translation>
     </message>
     <message>
-        <location filename="../src/bootentryform.cpp" line="97"/>
+        <location filename="../src/bootentryform.cpp" line="103"/>
         <source>Couldn&apos;t change optional data format!</source>
         <translation>Couldn&apos;t change optional data format!</translation>
     </message>
@@ -353,28 +370,28 @@
 <context>
     <name>EFIBootData</name>
     <message>
-        <location filename="../src/efibootdata.cpp" line="93"/>
-        <location filename="../src/efibootdata.cpp" line="583"/>
-        <location filename="../src/efibootdata.cpp" line="772"/>
-        <location filename="../src/efibootdata.cpp" line="1026"/>
-        <location filename="../src/efibootdata.cpp" line="1132"/>
+        <location filename="../src/efibootdata.cpp" line="97"/>
+        <location filename="../src/efibootdata.cpp" line="622"/>
+        <location filename="../src/efibootdata.cpp" line="812"/>
+        <location filename="../src/efibootdata.cpp" line="1067"/>
+        <location filename="../src/efibootdata.cpp" line="1173"/>
         <source>%1: not found</source>
         <translation>%1: not found</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="102"/>
-        <location filename="../src/efibootdata.cpp" line="592"/>
-        <location filename="../src/efibootdata.cpp" line="1052"/>
+        <location filename="../src/efibootdata.cpp" line="106"/>
+        <location filename="../src/efibootdata.cpp" line="631"/>
+        <location filename="../src/efibootdata.cpp" line="1093"/>
         <source>%1: failed deserialization</source>
         <translation>%1: failed deserialization</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Error loading entries</source>
         <translation>Error loading entries</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Failed to load some EFI Boot Manager entries:
 
   - %1</source>
@@ -383,79 +400,79 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Error saving entries</source>
         <translation>Error saving entries</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Entry %1(%2): duplicated index!</source>
         <translation>Entry %1(%2): duplicated index!</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="289"/>
-        <location filename="../src/efibootdata.cpp" line="322"/>
-        <location filename="../src/efibootdata.cpp" line="332"/>
-        <location filename="../src/efibootdata.cpp" line="340"/>
-        <location filename="../src/efibootdata.cpp" line="347"/>
-        <location filename="../src/efibootdata.cpp" line="366"/>
+        <location filename="../src/efibootdata.cpp" line="330"/>
+        <location filename="../src/efibootdata.cpp" line="360"/>
+        <location filename="../src/efibootdata.cpp" line="370"/>
+        <location filename="../src/efibootdata.cpp" line="378"/>
+        <location filename="../src/efibootdata.cpp" line="385"/>
+        <location filename="../src/efibootdata.cpp" line="404"/>
         <source>Error saving %1</source>
         <translation>Error saving %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="302"/>
-        <location filename="../src/efibootdata.cpp" line="313"/>
-        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="340"/>
+        <location filename="../src/efibootdata.cpp" line="351"/>
+        <location filename="../src/efibootdata.cpp" line="395"/>
         <source>Error removing %1</source>
         <translation>Error removing %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="399"/>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Error importing boot configuration</source>
         <translation>Error importing boot configuration</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="555"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
         <source>Couldn&apos;t open selected file (%1).</source>
         <translation>Couldn&apos;t open selected file (%1).</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="399"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
         <source>Invalid _Type: %1</source>
         <translation>Invalid _Type: %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
-        <location filename="../src/efibootdata.cpp" line="540"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
         <source>Error exporting boot configuration</source>
         <translation>Error exporting boot configuration</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
         <source>Couldn&apos;t open selected file (%1): %2.</source>
         <translation>Couldn&apos;t open selected file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="540"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
         <source>Couldn&apos;t write into file (%1): %2.</source>
         <translation>Couldn&apos;t write into file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="555"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Error dumping raw EFI data</source>
         <translation>Error dumping raw EFI data</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Failed to dump some EFI Boot Manager entries:
 
   - %1</source>
@@ -464,17 +481,17 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="660"/>
+        <location filename="../src/efibootdata.cpp" line="699"/>
         <source>Timeout</source>
         <translation>Timeout</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="676"/>
+        <location filename="../src/efibootdata.cpp" line="715"/>
         <source>Apple boot-args</source>
         <translation>Apple boot-args</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="692"/>
+        <location filename="../src/efibootdata.cpp" line="731"/>
         <source>Firmware actions</source>
         <translation>Firmware actions</translation>
     </message>
@@ -484,147 +501,147 @@
         <translation>Loading EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="81"/>
-        <location filename="../src/efibootdata.cpp" line="568"/>
+        <location filename="../src/efibootdata.cpp" line="85"/>
+        <location filename="../src/efibootdata.cpp" line="607"/>
         <source>Searching EFI Boot Manager entries…</source>
         <translation>Searching EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="98"/>
+        <location filename="../src/efibootdata.cpp" line="102"/>
         <source>Processing EFI Boot Manager entries (%1)…</source>
         <translation>Processing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="234"/>
+        <location filename="../src/efibootdata.cpp" line="262"/>
         <source>Saving EFI Boot Manager entries…</source>
         <translation>Saving EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="244"/>
+        <location filename="../src/efibootdata.cpp" line="282"/>
         <source>Searching old EFI Boot Manager entries…</source>
         <translation>Searching old EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="274"/>
-        <location filename="../src/efibootdata.cpp" line="319"/>
-        <location filename="../src/efibootdata.cpp" line="329"/>
-        <location filename="../src/efibootdata.cpp" line="337"/>
-        <location filename="../src/efibootdata.cpp" line="344"/>
-        <location filename="../src/efibootdata.cpp" line="363"/>
+        <location filename="../src/efibootdata.cpp" line="312"/>
+        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="367"/>
+        <location filename="../src/efibootdata.cpp" line="375"/>
+        <location filename="../src/efibootdata.cpp" line="382"/>
+        <location filename="../src/efibootdata.cpp" line="401"/>
         <source>Saving EFI Boot Manager entries (%1)…</source>
         <translation>Saving EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="299"/>
+        <location filename="../src/efibootdata.cpp" line="337"/>
         <source>Removing old EFI Boot Manager entries (%1)…</source>
         <translation>Removing old EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="310"/>
-        <location filename="../src/efibootdata.cpp" line="354"/>
+        <location filename="../src/efibootdata.cpp" line="348"/>
+        <location filename="../src/efibootdata.cpp" line="392"/>
         <source>Removing EFI Boot Manager entries (%1)…</source>
         <translation>Removing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="379"/>
-        <location filename="../src/efibootdata.cpp" line="759"/>
-        <location filename="../src/efibootdata.cpp" line="1013"/>
+        <location filename="../src/efibootdata.cpp" line="417"/>
+        <location filename="../src/efibootdata.cpp" line="798"/>
+        <location filename="../src/efibootdata.cpp" line="1053"/>
         <source>Importing boot configuration…</source>
         <translation>Importing boot configuration…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="408"/>
-        <location filename="../src/efibootdata.cpp" line="551"/>
+        <location filename="../src/efibootdata.cpp" line="446"/>
+        <location filename="../src/efibootdata.cpp" line="590"/>
         <source>Exporting boot configuration…</source>
         <translation>Exporting boot configuration…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="457"/>
-        <location filename="../src/efibootdata.cpp" line="588"/>
+        <location filename="../src/efibootdata.cpp" line="495"/>
+        <location filename="../src/efibootdata.cpp" line="627"/>
         <source>Exporting EFI Boot Manager entries (%1)…</source>
         <translation>Exporting EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="777"/>
-        <location filename="../src/efibootdata.cpp" line="1031"/>
+        <location filename="../src/efibootdata.cpp" line="817"/>
+        <location filename="../src/efibootdata.cpp" line="1072"/>
         <source>Importing EFI Boot Manager entries (%1)…</source>
         <translation>Importing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="780"/>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1041"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="820"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1082"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>%1: %2 expected</source>
         <translation>%1: %2 expected</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="788"/>
-        <location filename="../src/efibootdata.cpp" line="793"/>
-        <location filename="../src/efibootdata.cpp" line="798"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
+        <location filename="../src/efibootdata.cpp" line="828"/>
+        <location filename="../src/efibootdata.cpp" line="833"/>
+        <location filename="../src/efibootdata.cpp" line="838"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
         <source>number</source>
         <translation>number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="803"/>
-        <location filename="../src/efibootdata.cpp" line="808"/>
-        <location filename="../src/efibootdata.cpp" line="813"/>
-        <location filename="../src/efibootdata.cpp" line="818"/>
-        <location filename="../src/efibootdata.cpp" line="823"/>
+        <location filename="../src/efibootdata.cpp" line="843"/>
+        <location filename="../src/efibootdata.cpp" line="848"/>
+        <location filename="../src/efibootdata.cpp" line="853"/>
+        <location filename="../src/efibootdata.cpp" line="858"/>
+        <location filename="../src/efibootdata.cpp" line="863"/>
         <source>bool</source>
         <translation>bool</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="828"/>
-        <location filename="../src/efibootdata.cpp" line="872"/>
-        <location filename="../src/efibootdata.cpp" line="918"/>
+        <location filename="../src/efibootdata.cpp" line="868"/>
+        <location filename="../src/efibootdata.cpp" line="912"/>
+        <location filename="../src/efibootdata.cpp" line="958"/>
         <source>array</source>
         <translation>array</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="999"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="1039"/>
         <source>string</source>
         <translation>string</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="862"/>
-        <location filename="../src/efibootdata.cpp" line="898"/>
+        <location filename="../src/efibootdata.cpp" line="902"/>
+        <location filename="../src/efibootdata.cpp" line="938"/>
         <source>%1: unknown os indication</source>
         <translation>%1: unknown os indication</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="941"/>
-        <location filename="../src/efibootdata.cpp" line="969"/>
-        <location filename="../src/efibootdata.cpp" line="994"/>
+        <location filename="../src/efibootdata.cpp" line="981"/>
+        <location filename="../src/efibootdata.cpp" line="1009"/>
         <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>object</source>
         <translation>object</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
         <source>hexadecimal number</source>
         <translation>hexadecimal number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="975"/>
+        <location filename="../src/efibootdata.cpp" line="1015"/>
         <source>%1: failed parsing</source>
         <translation>%1: failed parsing</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Failed to import some EFI Boot Manager entries:
 
   - %1</source>
@@ -633,7 +650,7 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1044"/>
+        <location filename="../src/efibootdata.cpp" line="1085"/>
         <source>object(raw_data: string, efi_attributes: number)</source>
         <extracomment>Expected JSON structure, thrown as error description. raw_data and efi_attributes are field names in JSON file</extracomment>
         <translation>object(raw_data: string, efi_attributes: number)</translation>
@@ -668,8 +685,8 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="72"/>
-        <location filename="../src/efibooteditor.cpp" line="351"/>
-        <location filename="../src/efibooteditor.cpp" line="364"/>
+        <location filename="../src/efibooteditor.cpp" line="372"/>
+        <location filename="../src/efibooteditor.cpp" line="385"/>
         <source>Boot</source>
         <translation>Boot</translation>
     </message>
@@ -688,7 +705,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="134"/>
-        <location filename="../src/efibooteditor.cpp" line="354"/>
+        <location filename="../src/efibooteditor.cpp" line="375"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
@@ -707,7 +724,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="196"/>
-        <location filename="../src/efibooteditor.cpp" line="357"/>
+        <location filename="../src/efibooteditor.cpp" line="378"/>
         <source>System Preparation</source>
         <translation>System Preparation</translation>
     </message>
@@ -726,7 +743,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="258"/>
-        <location filename="../src/efibooteditor.cpp" line="360"/>
+        <location filename="../src/efibooteditor.cpp" line="381"/>
         <source>Platform Recovery</source>
         <translation>Platform Recovery</translation>
     </message>
@@ -1328,7 +1345,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="1280"/>
-        <location filename="../src/efibooteditor.cpp" line="235"/>
+        <location filename="../src/efibooteditor.cpp" line="238"/>
         <source>About EFI Boot Editor</source>
         <translation>About EFI Boot Editor</translation>
     </message>
@@ -1398,51 +1415,51 @@
         <translation>Are you sure you want to reorder the boot entries?&lt;br/&gt;All indexes will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="183"/>
+        <location filename="../src/efibooteditor.cpp" line="186"/>
         <source>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</source>
         <translation>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
         <source>Open boot configuration dump</source>
         <translation>Open boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>JSON documents (*.json)</source>
         <translation>JSON documents (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
         <source>Save boot configuration dump</source>
         <translation>Save boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>Save raw EFI dump</source>
         <translation>Save raw EFI dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="237"/>
+        <location filename="../src/efibooteditor.cpp" line="240"/>
         <source>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</source>
         <extracomment>About dialog</extracomment>
         <translation>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="245"/>
+        <location filename="../src/efibooteditor.cpp" line="248"/>
         <source>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</source>
         <extracomment>About dialog details</extracomment>
         <translation>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="297"/>
+        <location filename="../src/efibooteditor.cpp" line="300"/>
         <source>Reorder %1 entries</source>
         <translation>Reorder %1 entries</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="393"/>
+        <location filename="../src/efibooteditor.cpp" line="414"/>
         <source>Are you sure you want to quit?</source>
         <translation>Are you sure you want to quit?</translation>
     </message>
@@ -2491,8 +2508,8 @@
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unknown data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/filepathdialog.cpp" line="571"/>
-        <location filename="../src/filepathdialog.cpp" line="620"/>
+        <location filename="../src/filepathdialog.cpp" line="565"/>
+        <location filename="../src/filepathdialog.cpp" line="607"/>
         <source>Couldn&apos;t change Vendor data format!</source>
         <translation>Couldn&apos;t change Vendor data format!</translation>
     </message>

--- a/translations/efibooteditor_it.ts
+++ b/translations/efibooteditor_it.ts
@@ -4,37 +4,37 @@
 <context>
     <name>BootEntryForm</name>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="67"/>
-        <location filename="../src/form/bootentryform.ui" line="70"/>
-        <location filename="../src/form/bootentryform.ui" line="73"/>
-        <location filename="../src/form/bootentryform.ui" line="80"/>
-        <location filename="../src/form/bootentryform.ui" line="83"/>
+        <location filename="../src/form/bootentryform.ui" line="105"/>
+        <location filename="../src/form/bootentryform.ui" line="108"/>
+        <location filename="../src/form/bootentryform.ui" line="111"/>
+        <location filename="../src/form/bootentryform.ui" line="118"/>
+        <location filename="../src/form/bootentryform.ui" line="121"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="96"/>
-        <location filename="../src/form/bootentryform.ui" line="99"/>
-        <location filename="../src/form/bootentryform.ui" line="102"/>
+        <location filename="../src/form/bootentryform.ui" line="134"/>
+        <location filename="../src/form/bootentryform.ui" line="137"/>
+        <location filename="../src/form/bootentryform.ui" line="140"/>
         <source>Path</source>
         <translation>Percorso</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="318"/>
-        <location filename="../src/form/bootentryform.ui" line="321"/>
-        <location filename="../src/form/bootentryform.ui" line="381"/>
-        <location filename="../src/form/bootentryform.ui" line="384"/>
+        <location filename="../src/form/bootentryform.ui" line="356"/>
+        <location filename="../src/form/bootentryform.ui" line="359"/>
+        <location filename="../src/form/bootentryform.ui" line="419"/>
+        <location filename="../src/form/bootentryform.ui" line="422"/>
         <source>Optional data</source>
         <translation>Dati opzionali</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="324"/>
+        <location filename="../src/form/bootentryform.ui" line="362"/>
         <source>Optional</source>
         <translation>Opzionale</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="337"/>
-        <location filename="../src/form/bootentryform.ui" line="340"/>
+        <location filename="../src/form/bootentryform.ui" line="375"/>
+        <location filename="../src/form/bootentryform.ui" line="378"/>
         <source>Optional data format</source>
         <translation>Formato dati opzionali</translation>
     </message>
@@ -44,189 +44,206 @@
         <translation>Modulo voce boot</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="24"/>
+        <location filename="../src/form/bootentryform.ui" line="27"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="40"/>
+        <location filename="../src/form/bootentryform.ui" line="43"/>
+        <source>Error note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="46"/>
+        <source>This entry placeholder is shown here to indicate it&apos;s referenced in boot order. It won&apos;t be modified on save, just left as is.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Descrizione voce.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="120"/>
-        <location filename="../src/form/bootentryform.ui" line="123"/>
+        <location filename="../src/form/bootentryform.ui" line="158"/>
+        <location filename="../src/form/bootentryform.ui" line="161"/>
         <source>Device path</source>
         <translation>Percorso dispositivo</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="126"/>
+        <location filename="../src/form/bootentryform.ui" line="164"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Percorso dispositivo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="178"/>
-        <location filename="../src/form/bootentryform.ui" line="181"/>
+        <location filename="../src/form/bootentryform.ui" line="216"/>
+        <location filename="../src/form/bootentryform.ui" line="219"/>
         <source>Move file path up</source>
         <translation>Sposta percorso file su</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="184"/>
+        <location filename="../src/form/bootentryform.ui" line="222"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sposta percorso file su.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="204"/>
-        <location filename="../src/form/bootentryform.ui" line="207"/>
+        <location filename="../src/form/bootentryform.ui" line="242"/>
+        <location filename="../src/form/bootentryform.ui" line="245"/>
         <source>Move file path down</source>
         <translation>Sposta percorso file giù</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="210"/>
+        <location filename="../src/form/bootentryform.ui" line="248"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sposta percorso file giù.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="230"/>
-        <location filename="../src/form/bootentryform.ui" line="233"/>
+        <location filename="../src/form/bootentryform.ui" line="268"/>
+        <location filename="../src/form/bootentryform.ui" line="271"/>
         <source>Remove file path</source>
         <translation>Rimuovi percorso file</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="236"/>
+        <location filename="../src/form/bootentryform.ui" line="274"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rimuovi percorso file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="256"/>
-        <location filename="../src/form/bootentryform.ui" line="259"/>
+        <location filename="../src/form/bootentryform.ui" line="294"/>
+        <location filename="../src/form/bootentryform.ui" line="297"/>
         <source>Edit file path</source>
         <translation>Modifica percorso file</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="262"/>
+        <location filename="../src/form/bootentryform.ui" line="300"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modifica percorso file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="282"/>
-        <location filename="../src/form/bootentryform.ui" line="285"/>
+        <location filename="../src/form/bootentryform.ui" line="320"/>
+        <location filename="../src/form/bootentryform.ui" line="323"/>
         <source>Add file path</source>
         <translation>Aggiungi percorso file</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="288"/>
+        <location filename="../src/form/bootentryform.ui" line="326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aggiungi percorso file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="343"/>
+        <location filename="../src/form/bootentryform.ui" line="381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Formato dati opzionali.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="347"/>
+        <location filename="../src/form/bootentryform.ui" line="385"/>
         <source>BASE64</source>
         <translation>BASE64</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="352"/>
+        <location filename="../src/form/bootentryform.ui" line="390"/>
         <source>UTF-16</source>
         <translation>UTF-16</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="357"/>
+        <location filename="../src/form/bootentryform.ui" line="395"/>
         <source>UTF-8</source>
         <translation>UTF-8</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="362"/>
+        <location filename="../src/form/bootentryform.ui" line="400"/>
         <source>HEX</source>
         <translation>HEX</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="387"/>
+        <location filename="../src/form/bootentryform.ui" line="425"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dati opzionali voce.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="400"/>
-        <location filename="../src/form/bootentryform.ui" line="403"/>
-        <location filename="../src/form/bootentryform.ui" line="406"/>
+        <location filename="../src/form/bootentryform.ui" line="438"/>
+        <location filename="../src/form/bootentryform.ui" line="441"/>
+        <location filename="../src/form/bootentryform.ui" line="444"/>
         <source>Attributes</source>
         <translation>Attributi</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="526"/>
+        <location filename="../src/form/bootentryform.ui" line="564"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Categoria voce.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="54"/>
+        <location filename="../src/form/bootentryform.ui" line="92"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indice voce.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="443"/>
+        <location filename="../src/form/bootentryform.ui" line="481"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;La voce è considerata per l&apos;avvio automatico?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="472"/>
+        <location filename="../src/form/bootentryform.ui" line="510"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Nascosto.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="488"/>
+        <location filename="../src/form/bootentryform.ui" line="526"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Forza riconnessione.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="437"/>
-        <location filename="../src/form/bootentryform.ui" line="440"/>
-        <location filename="../src/form/bootentryform.ui" line="446"/>
+        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="478"/>
+        <location filename="../src/form/bootentryform.ui" line="484"/>
         <source>Active</source>
         <translation>Attivo</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="482"/>
-        <location filename="../src/form/bootentryform.ui" line="485"/>
-        <location filename="../src/form/bootentryform.ui" line="491"/>
+        <location filename="../src/form/bootentryform.ui" line="520"/>
+        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="529"/>
         <source>Force reconnect</source>
         <translation>Forza riconnessione</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="466"/>
-        <location filename="../src/form/bootentryform.ui" line="469"/>
-        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="504"/>
+        <location filename="../src/form/bootentryform.ui" line="507"/>
+        <location filename="../src/form/bootentryform.ui" line="513"/>
         <source>Hidden</source>
         <translation>Nascosto</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="501"/>
-        <location filename="../src/form/bootentryform.ui" line="504"/>
-        <location filename="../src/form/bootentryform.ui" line="507"/>
-        <location filename="../src/form/bootentryform.ui" line="520"/>
-        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="539"/>
+        <location filename="../src/form/bootentryform.ui" line="542"/>
+        <location filename="../src/form/bootentryform.ui" line="545"/>
+        <location filename="../src/form/bootentryform.ui" line="558"/>
+        <location filename="../src/form/bootentryform.ui" line="561"/>
         <source>Category</source>
         <translation>Categoria</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="530"/>
+        <location filename="../src/form/bootentryform.ui" line="568"/>
         <source>Boot</source>
         <translation>Boot</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="535"/>
+        <location filename="../src/form/bootentryform.ui" line="573"/>
         <source>App</source>
         <translation>App</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="30"/>
-        <location filename="../src/form/bootentryform.ui" line="33"/>
-        <location filename="../src/form/bootentryform.ui" line="36"/>
-        <location filename="../src/form/bootentryform.ui" line="48"/>
-        <location filename="../src/form/bootentryform.ui" line="51"/>
+        <location filename="../src/form/bootentryform.ui" line="68"/>
+        <location filename="../src/form/bootentryform.ui" line="71"/>
+        <location filename="../src/form/bootentryform.ui" line="74"/>
+        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="89"/>
         <source>Index</source>
         <translation>Indice</translation>
     </message>
     <message>
-        <location filename="../src/bootentryform.cpp" line="97"/>
+        <location filename="../src/bootentryform.cpp" line="103"/>
         <source>Couldn&apos;t change optional data format!</source>
         <translation>Impossibile modificare il formato dei dati opzionali!</translation>
     </message>
@@ -353,28 +370,28 @@
 <context>
     <name>EFIBootData</name>
     <message>
-        <location filename="../src/efibootdata.cpp" line="93"/>
-        <location filename="../src/efibootdata.cpp" line="583"/>
-        <location filename="../src/efibootdata.cpp" line="772"/>
-        <location filename="../src/efibootdata.cpp" line="1026"/>
-        <location filename="../src/efibootdata.cpp" line="1132"/>
+        <location filename="../src/efibootdata.cpp" line="97"/>
+        <location filename="../src/efibootdata.cpp" line="622"/>
+        <location filename="../src/efibootdata.cpp" line="812"/>
+        <location filename="../src/efibootdata.cpp" line="1067"/>
+        <location filename="../src/efibootdata.cpp" line="1173"/>
         <source>%1: not found</source>
         <translation>%1: non trovato</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="102"/>
-        <location filename="../src/efibootdata.cpp" line="592"/>
-        <location filename="../src/efibootdata.cpp" line="1052"/>
+        <location filename="../src/efibootdata.cpp" line="106"/>
+        <location filename="../src/efibootdata.cpp" line="631"/>
+        <location filename="../src/efibootdata.cpp" line="1093"/>
         <source>%1: failed deserialization</source>
         <translation>%1: deserializzazione fallita</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Error loading entries</source>
         <translation>Errore durante il caricamento delle voci</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Failed to load some EFI Boot Manager entries:
 
   - %1</source>
@@ -383,79 +400,79 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Error saving entries</source>
         <translation>Errore durante il salvataggio delle voci</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Entry %1(%2): duplicated index!</source>
         <translation>Voce %1(%2): indice duplicato!</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="289"/>
-        <location filename="../src/efibootdata.cpp" line="322"/>
-        <location filename="../src/efibootdata.cpp" line="332"/>
-        <location filename="../src/efibootdata.cpp" line="340"/>
-        <location filename="../src/efibootdata.cpp" line="347"/>
-        <location filename="../src/efibootdata.cpp" line="366"/>
+        <location filename="../src/efibootdata.cpp" line="330"/>
+        <location filename="../src/efibootdata.cpp" line="360"/>
+        <location filename="../src/efibootdata.cpp" line="370"/>
+        <location filename="../src/efibootdata.cpp" line="378"/>
+        <location filename="../src/efibootdata.cpp" line="385"/>
+        <location filename="../src/efibootdata.cpp" line="404"/>
         <source>Error saving %1</source>
         <translation>Errore durante il salvataggio di &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="302"/>
-        <location filename="../src/efibootdata.cpp" line="313"/>
-        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="340"/>
+        <location filename="../src/efibootdata.cpp" line="351"/>
+        <location filename="../src/efibootdata.cpp" line="395"/>
         <source>Error removing %1</source>
         <translation>Errore durante la rimozione di &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="399"/>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Error importing boot configuration</source>
         <translation>Errore durante l&apos;importazione della configurazione di boot</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="555"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
         <source>Couldn&apos;t open selected file (%1).</source>
         <translation>Impossibile aprire il file selezionato (%1).</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="399"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
         <source>Invalid _Type: %1</source>
         <translation>_Tipo non valido: %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
-        <location filename="../src/efibootdata.cpp" line="540"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
         <source>Error exporting boot configuration</source>
         <translation>Errore durante l&apos;esportazione della configurazione di boot</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
         <source>Couldn&apos;t open selected file (%1): %2.</source>
         <translation>Impossibile aprire il file selezionato (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="540"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
         <source>Couldn&apos;t write into file (%1): %2.</source>
         <translation>Impossibile scrivere nel file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="555"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Error dumping raw EFI data</source>
         <translation>Errore durante il dump dei dati EFI non elaborati</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Failed to dump some EFI Boot Manager entries:
 
   - %1</source>
@@ -464,17 +481,17 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="660"/>
+        <location filename="../src/efibootdata.cpp" line="699"/>
         <source>Timeout</source>
         <translation>Timeout</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="676"/>
+        <location filename="../src/efibootdata.cpp" line="715"/>
         <source>Apple boot-args</source>
         <translation>Argomenti boot Apple</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="692"/>
+        <location filename="../src/efibootdata.cpp" line="731"/>
         <source>Firmware actions</source>
         <translation>Azioni firmware</translation>
     </message>
@@ -484,147 +501,147 @@
         <translation>Caricamento voci EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="81"/>
-        <location filename="../src/efibootdata.cpp" line="568"/>
+        <location filename="../src/efibootdata.cpp" line="85"/>
+        <location filename="../src/efibootdata.cpp" line="607"/>
         <source>Searching EFI Boot Manager entries…</source>
         <translation>Ricerca voci EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="98"/>
+        <location filename="../src/efibootdata.cpp" line="102"/>
         <source>Processing EFI Boot Manager entries (%1)…</source>
         <translation>Elaborazione voci EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="234"/>
+        <location filename="../src/efibootdata.cpp" line="262"/>
         <source>Saving EFI Boot Manager entries…</source>
         <translation>Salvataggio voci EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="244"/>
+        <location filename="../src/efibootdata.cpp" line="282"/>
         <source>Searching old EFI Boot Manager entries…</source>
         <translation>Ricerca vecchie voci EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="274"/>
-        <location filename="../src/efibootdata.cpp" line="319"/>
-        <location filename="../src/efibootdata.cpp" line="329"/>
-        <location filename="../src/efibootdata.cpp" line="337"/>
-        <location filename="../src/efibootdata.cpp" line="344"/>
-        <location filename="../src/efibootdata.cpp" line="363"/>
+        <location filename="../src/efibootdata.cpp" line="312"/>
+        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="367"/>
+        <location filename="../src/efibootdata.cpp" line="375"/>
+        <location filename="../src/efibootdata.cpp" line="382"/>
+        <location filename="../src/efibootdata.cpp" line="401"/>
         <source>Saving EFI Boot Manager entries (%1)…</source>
         <translation>Salvataggio voci EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="299"/>
+        <location filename="../src/efibootdata.cpp" line="337"/>
         <source>Removing old EFI Boot Manager entries (%1)…</source>
         <translation>Rimozione vecchie voci EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="310"/>
-        <location filename="../src/efibootdata.cpp" line="354"/>
+        <location filename="../src/efibootdata.cpp" line="348"/>
+        <location filename="../src/efibootdata.cpp" line="392"/>
         <source>Removing EFI Boot Manager entries (%1)…</source>
         <translation>Rimozione voci EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="379"/>
-        <location filename="../src/efibootdata.cpp" line="759"/>
-        <location filename="../src/efibootdata.cpp" line="1013"/>
+        <location filename="../src/efibootdata.cpp" line="417"/>
+        <location filename="../src/efibootdata.cpp" line="798"/>
+        <location filename="../src/efibootdata.cpp" line="1053"/>
         <source>Importing boot configuration…</source>
         <translation>Importazione configurazione di boot…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="408"/>
-        <location filename="../src/efibootdata.cpp" line="551"/>
+        <location filename="../src/efibootdata.cpp" line="446"/>
+        <location filename="../src/efibootdata.cpp" line="590"/>
         <source>Exporting boot configuration…</source>
         <translation>Esportazione configurazione di boot…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="457"/>
-        <location filename="../src/efibootdata.cpp" line="588"/>
+        <location filename="../src/efibootdata.cpp" line="495"/>
+        <location filename="../src/efibootdata.cpp" line="627"/>
         <source>Exporting EFI Boot Manager entries (%1)…</source>
         <translation>Esportazione voci EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="777"/>
-        <location filename="../src/efibootdata.cpp" line="1031"/>
+        <location filename="../src/efibootdata.cpp" line="817"/>
+        <location filename="../src/efibootdata.cpp" line="1072"/>
         <source>Importing EFI Boot Manager entries (%1)…</source>
         <translation>Importazione voci EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="780"/>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1041"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="820"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1082"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>%1: %2 expected</source>
         <translation>%1: previsto %2</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="788"/>
-        <location filename="../src/efibootdata.cpp" line="793"/>
-        <location filename="../src/efibootdata.cpp" line="798"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
+        <location filename="../src/efibootdata.cpp" line="828"/>
+        <location filename="../src/efibootdata.cpp" line="833"/>
+        <location filename="../src/efibootdata.cpp" line="838"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
         <source>number</source>
         <translation>numero</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="803"/>
-        <location filename="../src/efibootdata.cpp" line="808"/>
-        <location filename="../src/efibootdata.cpp" line="813"/>
-        <location filename="../src/efibootdata.cpp" line="818"/>
-        <location filename="../src/efibootdata.cpp" line="823"/>
+        <location filename="../src/efibootdata.cpp" line="843"/>
+        <location filename="../src/efibootdata.cpp" line="848"/>
+        <location filename="../src/efibootdata.cpp" line="853"/>
+        <location filename="../src/efibootdata.cpp" line="858"/>
+        <location filename="../src/efibootdata.cpp" line="863"/>
         <source>bool</source>
         <translation>bool</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="828"/>
-        <location filename="../src/efibootdata.cpp" line="872"/>
-        <location filename="../src/efibootdata.cpp" line="918"/>
+        <location filename="../src/efibootdata.cpp" line="868"/>
+        <location filename="../src/efibootdata.cpp" line="912"/>
+        <location filename="../src/efibootdata.cpp" line="958"/>
         <source>array</source>
         <translation>matrice</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="999"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="1039"/>
         <source>string</source>
         <translation>stringa</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="862"/>
-        <location filename="../src/efibootdata.cpp" line="898"/>
+        <location filename="../src/efibootdata.cpp" line="902"/>
+        <location filename="../src/efibootdata.cpp" line="938"/>
         <source>%1: unknown os indication</source>
         <translation>%1: indicazione s.o. sconosciuto</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="941"/>
-        <location filename="../src/efibootdata.cpp" line="969"/>
-        <location filename="../src/efibootdata.cpp" line="994"/>
+        <location filename="../src/efibootdata.cpp" line="981"/>
+        <location filename="../src/efibootdata.cpp" line="1009"/>
         <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>object</source>
         <translation>oggetto</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
         <source>hexadecimal number</source>
         <translation>numero esadecimale</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="975"/>
+        <location filename="../src/efibootdata.cpp" line="1015"/>
         <source>%1: failed parsing</source>
         <translation>%1: analisi fallita</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Failed to import some EFI Boot Manager entries:
 
   - %1</source>
@@ -633,7 +650,7 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1044"/>
+        <location filename="../src/efibootdata.cpp" line="1085"/>
         <source>object(raw_data: string, efi_attributes: number)</source>
         <extracomment>Expected JSON structure, thrown as error description. raw_data and efi_attributes are field names in JSON file</extracomment>
         <translation>object(raw_data: string, efi_attributes: number)</translation>
@@ -668,8 +685,8 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="72"/>
-        <location filename="../src/efibooteditor.cpp" line="351"/>
-        <location filename="../src/efibooteditor.cpp" line="364"/>
+        <location filename="../src/efibooteditor.cpp" line="372"/>
+        <location filename="../src/efibooteditor.cpp" line="385"/>
         <source>Boot</source>
         <translation>Boot</translation>
     </message>
@@ -688,7 +705,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="134"/>
-        <location filename="../src/efibooteditor.cpp" line="354"/>
+        <location filename="../src/efibooteditor.cpp" line="375"/>
         <source>Driver</source>
         <translation>Driver</translation>
     </message>
@@ -707,7 +724,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="196"/>
-        <location filename="../src/efibooteditor.cpp" line="357"/>
+        <location filename="../src/efibooteditor.cpp" line="378"/>
         <source>System Preparation</source>
         <translation>Preparazione sistema</translation>
     </message>
@@ -726,7 +743,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="258"/>
-        <location filename="../src/efibooteditor.cpp" line="360"/>
+        <location filename="../src/efibooteditor.cpp" line="381"/>
         <source>Platform Recovery</source>
         <translation>Ripristino piattaforma</translation>
     </message>
@@ -1323,7 +1340,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="1280"/>
-        <location filename="../src/efibooteditor.cpp" line="235"/>
+        <location filename="../src/efibooteditor.cpp" line="238"/>
         <source>About EFI Boot Editor</source>
         <translation>Info su EFI Boot Editor</translation>
     </message>
@@ -1393,45 +1410,45 @@
         <translation>Sei sicuro di voler riordinare le voci di boot?&lt;br/&gt;Tutti gli indici verranno sovrascritti!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="183"/>
+        <location filename="../src/efibooteditor.cpp" line="186"/>
         <source>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</source>
         <translation>Sei sicuro di voler salvare?&lt;br/&gt;La configurazione EFI verrà sovrascritta!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
         <source>Open boot configuration dump</source>
         <translation>Apri dump configurazione di boot</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>JSON documents (*.json)</source>
         <translation>Documenti JSON (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
         <source>Save boot configuration dump</source>
         <translation>Salva dump configurazione di boot</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>Save raw EFI dump</source>
         <translation>Salva dump configurazione EFI grezza</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="245"/>
+        <location filename="../src/efibooteditor.cpp" line="248"/>
         <source>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</source>
         <extracomment>About dialog details</extracomment>
         <translation>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Il programma è fornito COSÌ COM&apos;È SENZA GARANZIE DI ALCUN TIPO, COMPRESA LA GARANZIA DI DESIGN, COMMERCIABILITÀ E IDONEITÀ PER UNO SCOPO PARTICOLARE.&lt;/p&gt;&lt;p&gt;Licenza: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Versione 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Per l&apos;accesso alle variabili EFI In Linux usa &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;Usa le icone di Tango come icone di riserva.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="297"/>
+        <location filename="../src/efibooteditor.cpp" line="300"/>
         <source>Reorder %1 entries</source>
         <translation>Riordina &apos;%1&apos; voci</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="393"/>
+        <location filename="../src/efibooteditor.cpp" line="414"/>
         <source>Are you sure you want to quit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
@@ -1441,7 +1458,7 @@
         <translation>È richiesto il supporto EFI</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="237"/>
+        <location filename="../src/efibooteditor.cpp" line="240"/>
         <source>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</source>
         <extracomment>About dialog</extracomment>
         <translation>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Versione &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor per sistemi basati su (U)EFI.&lt;/p&gt;</translation>
@@ -2491,8 +2508,8 @@
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dati sconosciuti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/filepathdialog.cpp" line="571"/>
-        <location filename="../src/filepathdialog.cpp" line="620"/>
+        <location filename="../src/filepathdialog.cpp" line="565"/>
+        <location filename="../src/filepathdialog.cpp" line="607"/>
         <source>Couldn&apos;t change Vendor data format!</source>
         <translation>Impossibile modificare il formato dei dati del produttore!</translation>
     </message>

--- a/translations/efibooteditor_nb_NO.ts
+++ b/translations/efibooteditor_nb_NO.ts
@@ -4,37 +4,37 @@
 <context>
     <name>BootEntryForm</name>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="67"/>
-        <location filename="../src/form/bootentryform.ui" line="70"/>
-        <location filename="../src/form/bootentryform.ui" line="73"/>
-        <location filename="../src/form/bootentryform.ui" line="80"/>
-        <location filename="../src/form/bootentryform.ui" line="83"/>
+        <location filename="../src/form/bootentryform.ui" line="105"/>
+        <location filename="../src/form/bootentryform.ui" line="108"/>
+        <location filename="../src/form/bootentryform.ui" line="111"/>
+        <location filename="../src/form/bootentryform.ui" line="118"/>
+        <location filename="../src/form/bootentryform.ui" line="121"/>
         <source>Description</source>
         <translation>Beskrivelse</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="96"/>
-        <location filename="../src/form/bootentryform.ui" line="99"/>
-        <location filename="../src/form/bootentryform.ui" line="102"/>
+        <location filename="../src/form/bootentryform.ui" line="134"/>
+        <location filename="../src/form/bootentryform.ui" line="137"/>
+        <location filename="../src/form/bootentryform.ui" line="140"/>
         <source>Path</source>
         <translation>Sti</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="318"/>
-        <location filename="../src/form/bootentryform.ui" line="321"/>
-        <location filename="../src/form/bootentryform.ui" line="381"/>
-        <location filename="../src/form/bootentryform.ui" line="384"/>
+        <location filename="../src/form/bootentryform.ui" line="356"/>
+        <location filename="../src/form/bootentryform.ui" line="359"/>
+        <location filename="../src/form/bootentryform.ui" line="419"/>
+        <location filename="../src/form/bootentryform.ui" line="422"/>
         <source>Optional data</source>
         <translation>Valgfri data</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="324"/>
+        <location filename="../src/form/bootentryform.ui" line="362"/>
         <source>Optional</source>
         <translation>Valgfritt</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="337"/>
-        <location filename="../src/form/bootentryform.ui" line="340"/>
+        <location filename="../src/form/bootentryform.ui" line="375"/>
+        <location filename="../src/form/bootentryform.ui" line="378"/>
         <source>Optional data format</source>
         <translation>Valgfritt datoformat</translation>
     </message>
@@ -44,189 +44,206 @@
         <translation>Oppstartsoppføringsskjema</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="24"/>
+        <location filename="../src/form/bootentryform.ui" line="27"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="40"/>
+        <location filename="../src/form/bootentryform.ui" line="43"/>
+        <source>Error note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="46"/>
+        <source>This entry placeholder is shown here to indicate it&apos;s referenced in boot order. It won&apos;t be modified on save, just left as is.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Oppføringsbeskrivelse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="120"/>
-        <location filename="../src/form/bootentryform.ui" line="123"/>
+        <location filename="../src/form/bootentryform.ui" line="158"/>
+        <location filename="../src/form/bootentryform.ui" line="161"/>
         <source>Device path</source>
         <translation>Enhetssti</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="126"/>
+        <location filename="../src/form/bootentryform.ui" line="164"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enhetssti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="178"/>
-        <location filename="../src/form/bootentryform.ui" line="181"/>
+        <location filename="../src/form/bootentryform.ui" line="216"/>
+        <location filename="../src/form/bootentryform.ui" line="219"/>
         <source>Move file path up</source>
         <translation>Flytt filsti oppover</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="184"/>
+        <location filename="../src/form/bootentryform.ui" line="222"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flytt filsti oppover.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="204"/>
-        <location filename="../src/form/bootentryform.ui" line="207"/>
+        <location filename="../src/form/bootentryform.ui" line="242"/>
+        <location filename="../src/form/bootentryform.ui" line="245"/>
         <source>Move file path down</source>
         <translation>Flytt filsti nedover</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="210"/>
+        <location filename="../src/form/bootentryform.ui" line="248"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Flytt filsti nedover.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="230"/>
-        <location filename="../src/form/bootentryform.ui" line="233"/>
+        <location filename="../src/form/bootentryform.ui" line="268"/>
+        <location filename="../src/form/bootentryform.ui" line="271"/>
         <source>Remove file path</source>
         <translation>Fjern filsti</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="236"/>
+        <location filename="../src/form/bootentryform.ui" line="274"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fjern filsti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="256"/>
-        <location filename="../src/form/bootentryform.ui" line="259"/>
+        <location filename="../src/form/bootentryform.ui" line="294"/>
+        <location filename="../src/form/bootentryform.ui" line="297"/>
         <source>Edit file path</source>
         <translation>Rediger filsti</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="262"/>
+        <location filename="../src/form/bootentryform.ui" line="300"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rediger filsti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="282"/>
-        <location filename="../src/form/bootentryform.ui" line="285"/>
+        <location filename="../src/form/bootentryform.ui" line="320"/>
+        <location filename="../src/form/bootentryform.ui" line="323"/>
         <source>Add file path</source>
         <translation>Legg til filsti</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="288"/>
+        <location filename="../src/form/bootentryform.ui" line="326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Legg til filsti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="343"/>
+        <location filename="../src/form/bootentryform.ui" line="381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Valgfritt datoformat.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="347"/>
+        <location filename="../src/form/bootentryform.ui" line="385"/>
         <source>BASE64</source>
         <translation type="unfinished">BASE64</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="352"/>
+        <location filename="../src/form/bootentryform.ui" line="390"/>
         <source>UTF-16</source>
         <translation type="unfinished">UTF-16</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="357"/>
+        <location filename="../src/form/bootentryform.ui" line="395"/>
         <source>UTF-8</source>
         <translation type="unfinished">UTF-8</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="362"/>
+        <location filename="../src/form/bootentryform.ui" line="400"/>
         <source>HEX</source>
         <translation type="unfinished">HEX</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="387"/>
+        <location filename="../src/form/bootentryform.ui" line="425"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="400"/>
-        <location filename="../src/form/bootentryform.ui" line="403"/>
-        <location filename="../src/form/bootentryform.ui" line="406"/>
+        <location filename="../src/form/bootentryform.ui" line="438"/>
+        <location filename="../src/form/bootentryform.ui" line="441"/>
+        <location filename="../src/form/bootentryform.ui" line="444"/>
         <source>Attributes</source>
         <translation type="unfinished">Attributes</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="526"/>
+        <location filename="../src/form/bootentryform.ui" line="564"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="54"/>
+        <location filename="../src/form/bootentryform.ui" line="92"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="443"/>
+        <location filename="../src/form/bootentryform.ui" line="481"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="472"/>
+        <location filename="../src/form/bootentryform.ui" line="510"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="488"/>
+        <location filename="../src/form/bootentryform.ui" line="526"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="437"/>
-        <location filename="../src/form/bootentryform.ui" line="440"/>
-        <location filename="../src/form/bootentryform.ui" line="446"/>
+        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="478"/>
+        <location filename="../src/form/bootentryform.ui" line="484"/>
         <source>Active</source>
         <translation type="unfinished">Active</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="482"/>
-        <location filename="../src/form/bootentryform.ui" line="485"/>
-        <location filename="../src/form/bootentryform.ui" line="491"/>
+        <location filename="../src/form/bootentryform.ui" line="520"/>
+        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="529"/>
         <source>Force reconnect</source>
         <translation type="unfinished">Force reconnect</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="466"/>
-        <location filename="../src/form/bootentryform.ui" line="469"/>
-        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="504"/>
+        <location filename="../src/form/bootentryform.ui" line="507"/>
+        <location filename="../src/form/bootentryform.ui" line="513"/>
         <source>Hidden</source>
         <translation type="unfinished">Hidden</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="501"/>
-        <location filename="../src/form/bootentryform.ui" line="504"/>
-        <location filename="../src/form/bootentryform.ui" line="507"/>
-        <location filename="../src/form/bootentryform.ui" line="520"/>
-        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="539"/>
+        <location filename="../src/form/bootentryform.ui" line="542"/>
+        <location filename="../src/form/bootentryform.ui" line="545"/>
+        <location filename="../src/form/bootentryform.ui" line="558"/>
+        <location filename="../src/form/bootentryform.ui" line="561"/>
         <source>Category</source>
         <translation type="unfinished">Category</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="530"/>
+        <location filename="../src/form/bootentryform.ui" line="568"/>
         <source>Boot</source>
         <translation type="unfinished">Boot</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="535"/>
+        <location filename="../src/form/bootentryform.ui" line="573"/>
         <source>App</source>
         <translation type="unfinished">App</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="30"/>
-        <location filename="../src/form/bootentryform.ui" line="33"/>
-        <location filename="../src/form/bootentryform.ui" line="36"/>
-        <location filename="../src/form/bootentryform.ui" line="48"/>
-        <location filename="../src/form/bootentryform.ui" line="51"/>
+        <location filename="../src/form/bootentryform.ui" line="68"/>
+        <location filename="../src/form/bootentryform.ui" line="71"/>
+        <location filename="../src/form/bootentryform.ui" line="74"/>
+        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="89"/>
         <source>Index</source>
         <translation type="unfinished">Index</translation>
     </message>
     <message>
-        <location filename="../src/bootentryform.cpp" line="97"/>
+        <location filename="../src/bootentryform.cpp" line="103"/>
         <source>Couldn&apos;t change optional data format!</source>
         <translation type="unfinished">Couldn&apos;t change optional data format!</translation>
     </message>
@@ -353,28 +370,28 @@
 <context>
     <name>EFIBootData</name>
     <message>
-        <location filename="../src/efibootdata.cpp" line="93"/>
-        <location filename="../src/efibootdata.cpp" line="583"/>
-        <location filename="../src/efibootdata.cpp" line="772"/>
-        <location filename="../src/efibootdata.cpp" line="1026"/>
-        <location filename="../src/efibootdata.cpp" line="1132"/>
+        <location filename="../src/efibootdata.cpp" line="97"/>
+        <location filename="../src/efibootdata.cpp" line="622"/>
+        <location filename="../src/efibootdata.cpp" line="812"/>
+        <location filename="../src/efibootdata.cpp" line="1067"/>
+        <location filename="../src/efibootdata.cpp" line="1173"/>
         <source>%1: not found</source>
         <translation type="unfinished">%1: not found</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="102"/>
-        <location filename="../src/efibootdata.cpp" line="592"/>
-        <location filename="../src/efibootdata.cpp" line="1052"/>
+        <location filename="../src/efibootdata.cpp" line="106"/>
+        <location filename="../src/efibootdata.cpp" line="631"/>
+        <location filename="../src/efibootdata.cpp" line="1093"/>
         <source>%1: failed deserialization</source>
         <translation type="unfinished">%1: failed deserialization</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Error loading entries</source>
         <translation type="unfinished">Error loading entries</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Failed to load some EFI Boot Manager entries:
 
   - %1</source>
@@ -383,79 +400,79 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Error saving entries</source>
         <translation type="unfinished">Error saving entries</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Entry %1(%2): duplicated index!</source>
         <translation type="unfinished">Entry %1(%2): duplicated index!</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="289"/>
-        <location filename="../src/efibootdata.cpp" line="322"/>
-        <location filename="../src/efibootdata.cpp" line="332"/>
-        <location filename="../src/efibootdata.cpp" line="340"/>
-        <location filename="../src/efibootdata.cpp" line="347"/>
-        <location filename="../src/efibootdata.cpp" line="366"/>
+        <location filename="../src/efibootdata.cpp" line="330"/>
+        <location filename="../src/efibootdata.cpp" line="360"/>
+        <location filename="../src/efibootdata.cpp" line="370"/>
+        <location filename="../src/efibootdata.cpp" line="378"/>
+        <location filename="../src/efibootdata.cpp" line="385"/>
+        <location filename="../src/efibootdata.cpp" line="404"/>
         <source>Error saving %1</source>
         <translation type="unfinished">Error saving %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="302"/>
-        <location filename="../src/efibootdata.cpp" line="313"/>
-        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="340"/>
+        <location filename="../src/efibootdata.cpp" line="351"/>
+        <location filename="../src/efibootdata.cpp" line="395"/>
         <source>Error removing %1</source>
         <translation type="unfinished">Error removing %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="399"/>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Error importing boot configuration</source>
         <translation type="unfinished">Error importing boot configuration</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="555"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
         <source>Couldn&apos;t open selected file (%1).</source>
         <translation type="unfinished">Couldn&apos;t open selected file (%1).</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="399"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
         <source>Invalid _Type: %1</source>
         <translation type="unfinished">Invalid _Type: %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
-        <location filename="../src/efibootdata.cpp" line="540"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
         <source>Error exporting boot configuration</source>
         <translation type="unfinished">Error exporting boot configuration</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
         <source>Couldn&apos;t open selected file (%1): %2.</source>
         <translation type="unfinished">Couldn&apos;t open selected file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="540"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
         <source>Couldn&apos;t write into file (%1): %2.</source>
         <translation type="unfinished">Couldn&apos;t write into file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="555"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Error dumping raw EFI data</source>
         <translation type="unfinished">Error dumping raw EFI data</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Failed to dump some EFI Boot Manager entries:
 
   - %1</source>
@@ -464,17 +481,17 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="660"/>
+        <location filename="../src/efibootdata.cpp" line="699"/>
         <source>Timeout</source>
         <translation type="unfinished">Timeout</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="676"/>
+        <location filename="../src/efibootdata.cpp" line="715"/>
         <source>Apple boot-args</source>
         <translation type="unfinished">Apple boot-args</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="692"/>
+        <location filename="../src/efibootdata.cpp" line="731"/>
         <source>Firmware actions</source>
         <translation type="unfinished">Firmware actions</translation>
     </message>
@@ -484,147 +501,147 @@
         <translation type="unfinished">Loading EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="81"/>
-        <location filename="../src/efibootdata.cpp" line="568"/>
+        <location filename="../src/efibootdata.cpp" line="85"/>
+        <location filename="../src/efibootdata.cpp" line="607"/>
         <source>Searching EFI Boot Manager entries…</source>
         <translation type="unfinished">Searching EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="98"/>
+        <location filename="../src/efibootdata.cpp" line="102"/>
         <source>Processing EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Processing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="234"/>
+        <location filename="../src/efibootdata.cpp" line="262"/>
         <source>Saving EFI Boot Manager entries…</source>
         <translation type="unfinished">Saving EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="244"/>
+        <location filename="../src/efibootdata.cpp" line="282"/>
         <source>Searching old EFI Boot Manager entries…</source>
         <translation type="unfinished">Searching old EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="274"/>
-        <location filename="../src/efibootdata.cpp" line="319"/>
-        <location filename="../src/efibootdata.cpp" line="329"/>
-        <location filename="../src/efibootdata.cpp" line="337"/>
-        <location filename="../src/efibootdata.cpp" line="344"/>
-        <location filename="../src/efibootdata.cpp" line="363"/>
+        <location filename="../src/efibootdata.cpp" line="312"/>
+        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="367"/>
+        <location filename="../src/efibootdata.cpp" line="375"/>
+        <location filename="../src/efibootdata.cpp" line="382"/>
+        <location filename="../src/efibootdata.cpp" line="401"/>
         <source>Saving EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Saving EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="299"/>
+        <location filename="../src/efibootdata.cpp" line="337"/>
         <source>Removing old EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Removing old EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="310"/>
-        <location filename="../src/efibootdata.cpp" line="354"/>
+        <location filename="../src/efibootdata.cpp" line="348"/>
+        <location filename="../src/efibootdata.cpp" line="392"/>
         <source>Removing EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Removing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="379"/>
-        <location filename="../src/efibootdata.cpp" line="759"/>
-        <location filename="../src/efibootdata.cpp" line="1013"/>
+        <location filename="../src/efibootdata.cpp" line="417"/>
+        <location filename="../src/efibootdata.cpp" line="798"/>
+        <location filename="../src/efibootdata.cpp" line="1053"/>
         <source>Importing boot configuration…</source>
         <translation type="unfinished">Importing boot configuration…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="408"/>
-        <location filename="../src/efibootdata.cpp" line="551"/>
+        <location filename="../src/efibootdata.cpp" line="446"/>
+        <location filename="../src/efibootdata.cpp" line="590"/>
         <source>Exporting boot configuration…</source>
         <translation type="unfinished">Exporting boot configuration…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="457"/>
-        <location filename="../src/efibootdata.cpp" line="588"/>
+        <location filename="../src/efibootdata.cpp" line="495"/>
+        <location filename="../src/efibootdata.cpp" line="627"/>
         <source>Exporting EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Exporting EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="777"/>
-        <location filename="../src/efibootdata.cpp" line="1031"/>
+        <location filename="../src/efibootdata.cpp" line="817"/>
+        <location filename="../src/efibootdata.cpp" line="1072"/>
         <source>Importing EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Importing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="780"/>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1041"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="820"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1082"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>%1: %2 expected</source>
         <translation type="unfinished">%1: %2 expected</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="788"/>
-        <location filename="../src/efibootdata.cpp" line="793"/>
-        <location filename="../src/efibootdata.cpp" line="798"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
+        <location filename="../src/efibootdata.cpp" line="828"/>
+        <location filename="../src/efibootdata.cpp" line="833"/>
+        <location filename="../src/efibootdata.cpp" line="838"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
         <source>number</source>
         <translation type="unfinished">number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="803"/>
-        <location filename="../src/efibootdata.cpp" line="808"/>
-        <location filename="../src/efibootdata.cpp" line="813"/>
-        <location filename="../src/efibootdata.cpp" line="818"/>
-        <location filename="../src/efibootdata.cpp" line="823"/>
+        <location filename="../src/efibootdata.cpp" line="843"/>
+        <location filename="../src/efibootdata.cpp" line="848"/>
+        <location filename="../src/efibootdata.cpp" line="853"/>
+        <location filename="../src/efibootdata.cpp" line="858"/>
+        <location filename="../src/efibootdata.cpp" line="863"/>
         <source>bool</source>
         <translation type="unfinished">bool</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="828"/>
-        <location filename="../src/efibootdata.cpp" line="872"/>
-        <location filename="../src/efibootdata.cpp" line="918"/>
+        <location filename="../src/efibootdata.cpp" line="868"/>
+        <location filename="../src/efibootdata.cpp" line="912"/>
+        <location filename="../src/efibootdata.cpp" line="958"/>
         <source>array</source>
         <translation type="unfinished">array</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="999"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="1039"/>
         <source>string</source>
         <translation type="unfinished">string</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="862"/>
-        <location filename="../src/efibootdata.cpp" line="898"/>
+        <location filename="../src/efibootdata.cpp" line="902"/>
+        <location filename="../src/efibootdata.cpp" line="938"/>
         <source>%1: unknown os indication</source>
         <translation type="unfinished">%1: unknown os indication</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="941"/>
-        <location filename="../src/efibootdata.cpp" line="969"/>
-        <location filename="../src/efibootdata.cpp" line="994"/>
+        <location filename="../src/efibootdata.cpp" line="981"/>
+        <location filename="../src/efibootdata.cpp" line="1009"/>
         <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>object</source>
         <translation type="unfinished">object</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
         <source>hexadecimal number</source>
         <translation type="unfinished">hexadecimal number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="975"/>
+        <location filename="../src/efibootdata.cpp" line="1015"/>
         <source>%1: failed parsing</source>
         <translation type="unfinished">%1: failed parsing</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Failed to import some EFI Boot Manager entries:
 
   - %1</source>
@@ -633,7 +650,7 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1044"/>
+        <location filename="../src/efibootdata.cpp" line="1085"/>
         <source>object(raw_data: string, efi_attributes: number)</source>
         <extracomment>Expected JSON structure, thrown as error description. raw_data and efi_attributes are field names in JSON file</extracomment>
         <translation type="unfinished">object(raw_data: string, efi_attributes: number)</translation>
@@ -668,8 +685,8 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="72"/>
-        <location filename="../src/efibooteditor.cpp" line="351"/>
-        <location filename="../src/efibooteditor.cpp" line="364"/>
+        <location filename="../src/efibooteditor.cpp" line="372"/>
+        <location filename="../src/efibooteditor.cpp" line="385"/>
         <source>Boot</source>
         <translation type="unfinished">Boot</translation>
     </message>
@@ -688,7 +705,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="134"/>
-        <location filename="../src/efibooteditor.cpp" line="354"/>
+        <location filename="../src/efibooteditor.cpp" line="375"/>
         <source>Driver</source>
         <translation type="unfinished">Driver</translation>
     </message>
@@ -707,7 +724,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="196"/>
-        <location filename="../src/efibooteditor.cpp" line="357"/>
+        <location filename="../src/efibooteditor.cpp" line="378"/>
         <source>System Preparation</source>
         <translation type="unfinished">System Preparation</translation>
     </message>
@@ -726,7 +743,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="258"/>
-        <location filename="../src/efibooteditor.cpp" line="360"/>
+        <location filename="../src/efibooteditor.cpp" line="381"/>
         <source>Platform Recovery</source>
         <translation type="unfinished">Platform Recovery</translation>
     </message>
@@ -1328,7 +1345,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="1280"/>
-        <location filename="../src/efibooteditor.cpp" line="235"/>
+        <location filename="../src/efibooteditor.cpp" line="238"/>
         <source>About EFI Boot Editor</source>
         <translation type="unfinished">About EFI Boot Editor</translation>
     </message>
@@ -1398,56 +1415,56 @@
         <translation type="unfinished">Are you sure you want to reorder the boot entries?&lt;br/&gt;All indexes will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="183"/>
+        <location filename="../src/efibooteditor.cpp" line="186"/>
         <source>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</source>
         <translation type="unfinished">Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
         <source>Open boot configuration dump</source>
         <translation type="unfinished">Open boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>JSON documents (*.json)</source>
         <translation type="unfinished">JSON documents (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
         <source>Save boot configuration dump</source>
         <translation type="unfinished">Save boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>Save raw EFI dump</source>
         <translation type="unfinished">Save raw EFI dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="237"/>
+        <location filename="../src/efibooteditor.cpp" line="240"/>
         <source>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</source>
         <extracomment>About dialog</extracomment>
         <translation type="unfinished">&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="245"/>
+        <location filename="../src/efibooteditor.cpp" line="248"/>
         <source>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</source>
         <extracomment>About dialog details</extracomment>
         <translation type="unfinished">&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="297"/>
+        <location filename="../src/efibooteditor.cpp" line="300"/>
         <source>Reorder %1 entries</source>
         <translation type="unfinished">Reorder %1 entries</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="393"/>
+        <location filename="../src/efibooteditor.cpp" line="414"/>
         <source>Are you sure you want to quit?</source>
         <translation type="unfinished">Are you sure you want to quit?</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="40"/>
+        <location filename="../src/main.cpp" line="42"/>
         <source>EFI support required</source>
         <translation type="unfinished">EFI support required</translation>
     </message>
@@ -2491,8 +2508,8 @@
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unknown data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/filepathdialog.cpp" line="571"/>
-        <location filename="../src/filepathdialog.cpp" line="620"/>
+        <location filename="../src/filepathdialog.cpp" line="565"/>
+        <location filename="../src/filepathdialog.cpp" line="607"/>
         <source>Couldn&apos;t change Vendor data format!</source>
         <translation type="unfinished">Couldn&apos;t change Vendor data format!</translation>
     </message>

--- a/translations/efibooteditor_pl.ts
+++ b/translations/efibooteditor_pl.ts
@@ -4,37 +4,37 @@
 <context>
     <name>BootEntryForm</name>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="67"/>
-        <location filename="../src/form/bootentryform.ui" line="70"/>
-        <location filename="../src/form/bootentryform.ui" line="73"/>
-        <location filename="../src/form/bootentryform.ui" line="80"/>
-        <location filename="../src/form/bootentryform.ui" line="83"/>
+        <location filename="../src/form/bootentryform.ui" line="105"/>
+        <location filename="../src/form/bootentryform.ui" line="108"/>
+        <location filename="../src/form/bootentryform.ui" line="111"/>
+        <location filename="../src/form/bootentryform.ui" line="118"/>
+        <location filename="../src/form/bootentryform.ui" line="121"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="96"/>
-        <location filename="../src/form/bootentryform.ui" line="99"/>
-        <location filename="../src/form/bootentryform.ui" line="102"/>
+        <location filename="../src/form/bootentryform.ui" line="134"/>
+        <location filename="../src/form/bootentryform.ui" line="137"/>
+        <location filename="../src/form/bootentryform.ui" line="140"/>
         <source>Path</source>
         <translation>Ścieżka</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="318"/>
-        <location filename="../src/form/bootentryform.ui" line="321"/>
-        <location filename="../src/form/bootentryform.ui" line="381"/>
-        <location filename="../src/form/bootentryform.ui" line="384"/>
+        <location filename="../src/form/bootentryform.ui" line="356"/>
+        <location filename="../src/form/bootentryform.ui" line="359"/>
+        <location filename="../src/form/bootentryform.ui" line="419"/>
+        <location filename="../src/form/bootentryform.ui" line="422"/>
         <source>Optional data</source>
         <translation>Dodatkowe dane</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="324"/>
+        <location filename="../src/form/bootentryform.ui" line="362"/>
         <source>Optional</source>
         <translation>Dodatkowe</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="337"/>
-        <location filename="../src/form/bootentryform.ui" line="340"/>
+        <location filename="../src/form/bootentryform.ui" line="375"/>
+        <location filename="../src/form/bootentryform.ui" line="378"/>
         <source>Optional data format</source>
         <translation>Format danych dodatkowych</translation>
     </message>
@@ -44,189 +44,206 @@
         <translation>Formularz wpisu rozruchu</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="24"/>
+        <location filename="../src/form/bootentryform.ui" line="27"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="40"/>
+        <location filename="../src/form/bootentryform.ui" line="43"/>
+        <source>Error note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="46"/>
+        <source>This entry placeholder is shown here to indicate it&apos;s referenced in boot order. It won&apos;t be modified on save, just left as is.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opis wpisu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="120"/>
-        <location filename="../src/form/bootentryform.ui" line="123"/>
+        <location filename="../src/form/bootentryform.ui" line="158"/>
+        <location filename="../src/form/bootentryform.ui" line="161"/>
         <source>Device path</source>
         <translation>Ścieżka urządzenia</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="126"/>
+        <location filename="../src/form/bootentryform.ui" line="164"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ścieżka urządzenia.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="178"/>
-        <location filename="../src/form/bootentryform.ui" line="181"/>
+        <location filename="../src/form/bootentryform.ui" line="216"/>
+        <location filename="../src/form/bootentryform.ui" line="219"/>
         <source>Move file path up</source>
         <translation>Przenieś ścieżkę w górę</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="184"/>
+        <location filename="../src/form/bootentryform.ui" line="222"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Przenieś ścieżkę w górę.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="204"/>
-        <location filename="../src/form/bootentryform.ui" line="207"/>
+        <location filename="../src/form/bootentryform.ui" line="242"/>
+        <location filename="../src/form/bootentryform.ui" line="245"/>
         <source>Move file path down</source>
         <translation>Przenieś ścieżkę w dół</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="210"/>
+        <location filename="../src/form/bootentryform.ui" line="248"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Przenieś ścieżkę w dół.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="230"/>
-        <location filename="../src/form/bootentryform.ui" line="233"/>
+        <location filename="../src/form/bootentryform.ui" line="268"/>
+        <location filename="../src/form/bootentryform.ui" line="271"/>
         <source>Remove file path</source>
         <translation>Usuń ścieżkę</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="236"/>
+        <location filename="../src/form/bootentryform.ui" line="274"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Usuń ścieżkę.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="256"/>
-        <location filename="../src/form/bootentryform.ui" line="259"/>
+        <location filename="../src/form/bootentryform.ui" line="294"/>
+        <location filename="../src/form/bootentryform.ui" line="297"/>
         <source>Edit file path</source>
         <translation>Edytuj ścieżkę</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="262"/>
+        <location filename="../src/form/bootentryform.ui" line="300"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edytuj ścieżkę.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="282"/>
-        <location filename="../src/form/bootentryform.ui" line="285"/>
+        <location filename="../src/form/bootentryform.ui" line="320"/>
+        <location filename="../src/form/bootentryform.ui" line="323"/>
         <source>Add file path</source>
         <translation>Dodaj ścieżkę</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="288"/>
+        <location filename="../src/form/bootentryform.ui" line="326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dodaj ścieżkę.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="343"/>
+        <location filename="../src/form/bootentryform.ui" line="381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Format danych dodatkowych.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="347"/>
+        <location filename="../src/form/bootentryform.ui" line="385"/>
         <source>BASE64</source>
         <translation>BASE64</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="352"/>
+        <location filename="../src/form/bootentryform.ui" line="390"/>
         <source>UTF-16</source>
         <translation>UTF-16</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="357"/>
+        <location filename="../src/form/bootentryform.ui" line="395"/>
         <source>UTF-8</source>
         <translation>UTF-8</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="362"/>
+        <location filename="../src/form/bootentryform.ui" line="400"/>
         <source>HEX</source>
         <translation>HEX</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="387"/>
+        <location filename="../src/form/bootentryform.ui" line="425"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dodatkowe dane wpisu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="400"/>
-        <location filename="../src/form/bootentryform.ui" line="403"/>
-        <location filename="../src/form/bootentryform.ui" line="406"/>
+        <location filename="../src/form/bootentryform.ui" line="438"/>
+        <location filename="../src/form/bootentryform.ui" line="441"/>
+        <location filename="../src/form/bootentryform.ui" line="444"/>
         <source>Attributes</source>
         <translation>Atrybuty</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="526"/>
+        <location filename="../src/form/bootentryform.ui" line="564"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kategoria wpisu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="54"/>
+        <location filename="../src/form/bootentryform.ui" line="92"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indeks wpisu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="443"/>
+        <location filename="../src/form/bootentryform.ui" line="481"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Czy wpis jest brany pod uwagę przy automatycznym uruchamianiu?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="472"/>
+        <location filename="../src/form/bootentryform.ui" line="510"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ukryty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="488"/>
+        <location filename="../src/form/bootentryform.ui" line="526"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Wymuś ponowne połączenie.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="437"/>
-        <location filename="../src/form/bootentryform.ui" line="440"/>
-        <location filename="../src/form/bootentryform.ui" line="446"/>
+        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="478"/>
+        <location filename="../src/form/bootentryform.ui" line="484"/>
         <source>Active</source>
         <translation>Aktywny</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="482"/>
-        <location filename="../src/form/bootentryform.ui" line="485"/>
-        <location filename="../src/form/bootentryform.ui" line="491"/>
+        <location filename="../src/form/bootentryform.ui" line="520"/>
+        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="529"/>
         <source>Force reconnect</source>
         <translation>Wymuś ponowne połączenie</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="466"/>
-        <location filename="../src/form/bootentryform.ui" line="469"/>
-        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="504"/>
+        <location filename="../src/form/bootentryform.ui" line="507"/>
+        <location filename="../src/form/bootentryform.ui" line="513"/>
         <source>Hidden</source>
         <translation>Ukryty</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="501"/>
-        <location filename="../src/form/bootentryform.ui" line="504"/>
-        <location filename="../src/form/bootentryform.ui" line="507"/>
-        <location filename="../src/form/bootentryform.ui" line="520"/>
-        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="539"/>
+        <location filename="../src/form/bootentryform.ui" line="542"/>
+        <location filename="../src/form/bootentryform.ui" line="545"/>
+        <location filename="../src/form/bootentryform.ui" line="558"/>
+        <location filename="../src/form/bootentryform.ui" line="561"/>
         <source>Category</source>
         <translation>Kategoria</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="530"/>
+        <location filename="../src/form/bootentryform.ui" line="568"/>
         <source>Boot</source>
         <translation>Rozruch</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="535"/>
+        <location filename="../src/form/bootentryform.ui" line="573"/>
         <source>App</source>
         <translation>Aplikacja</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="30"/>
-        <location filename="../src/form/bootentryform.ui" line="33"/>
-        <location filename="../src/form/bootentryform.ui" line="36"/>
-        <location filename="../src/form/bootentryform.ui" line="48"/>
-        <location filename="../src/form/bootentryform.ui" line="51"/>
+        <location filename="../src/form/bootentryform.ui" line="68"/>
+        <location filename="../src/form/bootentryform.ui" line="71"/>
+        <location filename="../src/form/bootentryform.ui" line="74"/>
+        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="89"/>
         <source>Index</source>
         <translation>Indeks</translation>
     </message>
     <message>
-        <location filename="../src/bootentryform.cpp" line="97"/>
+        <location filename="../src/bootentryform.cpp" line="103"/>
         <source>Couldn&apos;t change optional data format!</source>
         <translation>Nie można zmienić formatu danych dodatkowych!</translation>
     </message>
@@ -236,7 +253,7 @@
     <message>
         <location filename="../src/bootentrylistmodel.cpp" line="50"/>
         <source>Set Next boot to &quot;%1&quot;</source>
-        <translation>Ustaw następny rozruch na „% 1”</translation>
+        <translation>Ustaw następny rozruch na „%1”</translation>
     </message>
     <message>
         <location filename="../src/bootentrylistmodel.cpp" line="146"/>
@@ -353,28 +370,28 @@
 <context>
     <name>EFIBootData</name>
     <message>
-        <location filename="../src/efibootdata.cpp" line="93"/>
-        <location filename="../src/efibootdata.cpp" line="583"/>
-        <location filename="../src/efibootdata.cpp" line="772"/>
-        <location filename="../src/efibootdata.cpp" line="1026"/>
-        <location filename="../src/efibootdata.cpp" line="1132"/>
+        <location filename="../src/efibootdata.cpp" line="97"/>
+        <location filename="../src/efibootdata.cpp" line="622"/>
+        <location filename="../src/efibootdata.cpp" line="812"/>
+        <location filename="../src/efibootdata.cpp" line="1067"/>
+        <location filename="../src/efibootdata.cpp" line="1173"/>
         <source>%1: not found</source>
         <translation>%1: nie znaleziono</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="102"/>
-        <location filename="../src/efibootdata.cpp" line="592"/>
-        <location filename="../src/efibootdata.cpp" line="1052"/>
+        <location filename="../src/efibootdata.cpp" line="106"/>
+        <location filename="../src/efibootdata.cpp" line="631"/>
+        <location filename="../src/efibootdata.cpp" line="1093"/>
         <source>%1: failed deserialization</source>
         <translation>%1: deserializacja nie powiodła się</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Error loading entries</source>
         <translation>Błąd ładowania wpisów</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Failed to load some EFI Boot Manager entries:
 
   - %1</source>
@@ -383,79 +400,79 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Error saving entries</source>
         <translation>Błąd podczas zapisywania wpisów</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Entry %1(%2): duplicated index!</source>
         <translation>Wpis %1(%2): zduplikowany indeks!</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="289"/>
-        <location filename="../src/efibootdata.cpp" line="322"/>
-        <location filename="../src/efibootdata.cpp" line="332"/>
-        <location filename="../src/efibootdata.cpp" line="340"/>
-        <location filename="../src/efibootdata.cpp" line="347"/>
-        <location filename="../src/efibootdata.cpp" line="366"/>
+        <location filename="../src/efibootdata.cpp" line="330"/>
+        <location filename="../src/efibootdata.cpp" line="360"/>
+        <location filename="../src/efibootdata.cpp" line="370"/>
+        <location filename="../src/efibootdata.cpp" line="378"/>
+        <location filename="../src/efibootdata.cpp" line="385"/>
+        <location filename="../src/efibootdata.cpp" line="404"/>
         <source>Error saving %1</source>
         <translation>Błąd podczas zapisywania %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="302"/>
-        <location filename="../src/efibootdata.cpp" line="313"/>
-        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="340"/>
+        <location filename="../src/efibootdata.cpp" line="351"/>
+        <location filename="../src/efibootdata.cpp" line="395"/>
         <source>Error removing %1</source>
         <translation>Błąd podczas usuwania %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="399"/>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Error importing boot configuration</source>
         <translation>Błąd podczas importowania konfiguracji rozruchu</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="555"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
         <source>Couldn&apos;t open selected file (%1).</source>
         <translation>Nie można otworzyć wybranego pliku (%1).</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="399"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
         <source>Invalid _Type: %1</source>
         <translation type="unfinished">Niepoprawny _Typ: %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
-        <location filename="../src/efibootdata.cpp" line="540"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
         <source>Error exporting boot configuration</source>
         <translation type="unfinished">Error exporting boot configuration</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
         <source>Couldn&apos;t open selected file (%1): %2.</source>
         <translation type="unfinished">Couldn&apos;t open selected file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="540"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
         <source>Couldn&apos;t write into file (%1): %2.</source>
         <translation type="unfinished">Couldn&apos;t write into file (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="555"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Error dumping raw EFI data</source>
         <translation type="unfinished">Error dumping raw EFI data</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Failed to dump some EFI Boot Manager entries:
 
   - %1</source>
@@ -464,17 +481,17 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="660"/>
+        <location filename="../src/efibootdata.cpp" line="699"/>
         <source>Timeout</source>
         <translation type="unfinished">Timeout</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="676"/>
+        <location filename="../src/efibootdata.cpp" line="715"/>
         <source>Apple boot-args</source>
         <translation type="unfinished">Apple boot-args</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="692"/>
+        <location filename="../src/efibootdata.cpp" line="731"/>
         <source>Firmware actions</source>
         <translation type="unfinished">Firmware actions</translation>
     </message>
@@ -484,147 +501,147 @@
         <translation type="unfinished">Loading EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="81"/>
-        <location filename="../src/efibootdata.cpp" line="568"/>
+        <location filename="../src/efibootdata.cpp" line="85"/>
+        <location filename="../src/efibootdata.cpp" line="607"/>
         <source>Searching EFI Boot Manager entries…</source>
         <translation type="unfinished">Searching EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="98"/>
+        <location filename="../src/efibootdata.cpp" line="102"/>
         <source>Processing EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Processing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="234"/>
+        <location filename="../src/efibootdata.cpp" line="262"/>
         <source>Saving EFI Boot Manager entries…</source>
         <translation type="unfinished">Saving EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="244"/>
+        <location filename="../src/efibootdata.cpp" line="282"/>
         <source>Searching old EFI Boot Manager entries…</source>
         <translation type="unfinished">Searching old EFI Boot Manager entries…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="274"/>
-        <location filename="../src/efibootdata.cpp" line="319"/>
-        <location filename="../src/efibootdata.cpp" line="329"/>
-        <location filename="../src/efibootdata.cpp" line="337"/>
-        <location filename="../src/efibootdata.cpp" line="344"/>
-        <location filename="../src/efibootdata.cpp" line="363"/>
+        <location filename="../src/efibootdata.cpp" line="312"/>
+        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="367"/>
+        <location filename="../src/efibootdata.cpp" line="375"/>
+        <location filename="../src/efibootdata.cpp" line="382"/>
+        <location filename="../src/efibootdata.cpp" line="401"/>
         <source>Saving EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Saving EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="299"/>
+        <location filename="../src/efibootdata.cpp" line="337"/>
         <source>Removing old EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Removing old EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="310"/>
-        <location filename="../src/efibootdata.cpp" line="354"/>
+        <location filename="../src/efibootdata.cpp" line="348"/>
+        <location filename="../src/efibootdata.cpp" line="392"/>
         <source>Removing EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Removing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="379"/>
-        <location filename="../src/efibootdata.cpp" line="759"/>
-        <location filename="../src/efibootdata.cpp" line="1013"/>
+        <location filename="../src/efibootdata.cpp" line="417"/>
+        <location filename="../src/efibootdata.cpp" line="798"/>
+        <location filename="../src/efibootdata.cpp" line="1053"/>
         <source>Importing boot configuration…</source>
         <translation type="unfinished">Importing boot configuration…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="408"/>
-        <location filename="../src/efibootdata.cpp" line="551"/>
+        <location filename="../src/efibootdata.cpp" line="446"/>
+        <location filename="../src/efibootdata.cpp" line="590"/>
         <source>Exporting boot configuration…</source>
         <translation type="unfinished">Exporting boot configuration…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="457"/>
-        <location filename="../src/efibootdata.cpp" line="588"/>
+        <location filename="../src/efibootdata.cpp" line="495"/>
+        <location filename="../src/efibootdata.cpp" line="627"/>
         <source>Exporting EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Exporting EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="777"/>
-        <location filename="../src/efibootdata.cpp" line="1031"/>
+        <location filename="../src/efibootdata.cpp" line="817"/>
+        <location filename="../src/efibootdata.cpp" line="1072"/>
         <source>Importing EFI Boot Manager entries (%1)…</source>
         <translation type="unfinished">Importing EFI Boot Manager entries (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="780"/>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1041"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="820"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1082"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>%1: %2 expected</source>
         <translation type="unfinished">%1: %2 expected</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="788"/>
-        <location filename="../src/efibootdata.cpp" line="793"/>
-        <location filename="../src/efibootdata.cpp" line="798"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
+        <location filename="../src/efibootdata.cpp" line="828"/>
+        <location filename="../src/efibootdata.cpp" line="833"/>
+        <location filename="../src/efibootdata.cpp" line="838"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
         <source>number</source>
         <translation type="unfinished">number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="803"/>
-        <location filename="../src/efibootdata.cpp" line="808"/>
-        <location filename="../src/efibootdata.cpp" line="813"/>
-        <location filename="../src/efibootdata.cpp" line="818"/>
-        <location filename="../src/efibootdata.cpp" line="823"/>
+        <location filename="../src/efibootdata.cpp" line="843"/>
+        <location filename="../src/efibootdata.cpp" line="848"/>
+        <location filename="../src/efibootdata.cpp" line="853"/>
+        <location filename="../src/efibootdata.cpp" line="858"/>
+        <location filename="../src/efibootdata.cpp" line="863"/>
         <source>bool</source>
         <translation type="unfinished">bool</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="828"/>
-        <location filename="../src/efibootdata.cpp" line="872"/>
-        <location filename="../src/efibootdata.cpp" line="918"/>
+        <location filename="../src/efibootdata.cpp" line="868"/>
+        <location filename="../src/efibootdata.cpp" line="912"/>
+        <location filename="../src/efibootdata.cpp" line="958"/>
         <source>array</source>
         <translation type="unfinished">array</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="999"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="1039"/>
         <source>string</source>
         <translation type="unfinished">string</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="862"/>
-        <location filename="../src/efibootdata.cpp" line="898"/>
+        <location filename="../src/efibootdata.cpp" line="902"/>
+        <location filename="../src/efibootdata.cpp" line="938"/>
         <source>%1: unknown os indication</source>
         <translation type="unfinished">%1: unknown os indication</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="941"/>
-        <location filename="../src/efibootdata.cpp" line="969"/>
-        <location filename="../src/efibootdata.cpp" line="994"/>
+        <location filename="../src/efibootdata.cpp" line="981"/>
+        <location filename="../src/efibootdata.cpp" line="1009"/>
         <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>object</source>
         <translation type="unfinished">object</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
         <source>hexadecimal number</source>
         <translation type="unfinished">hexadecimal number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="975"/>
+        <location filename="../src/efibootdata.cpp" line="1015"/>
         <source>%1: failed parsing</source>
         <translation type="unfinished">%1: failed parsing</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Failed to import some EFI Boot Manager entries:
 
   - %1</source>
@@ -633,7 +650,7 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1044"/>
+        <location filename="../src/efibootdata.cpp" line="1085"/>
         <source>object(raw_data: string, efi_attributes: number)</source>
         <extracomment>Expected JSON structure, thrown as error description. raw_data and efi_attributes are field names in JSON file</extracomment>
         <translation type="unfinished">object(raw_data: string, efi_attributes: number)</translation>
@@ -668,8 +685,8 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="72"/>
-        <location filename="../src/efibooteditor.cpp" line="351"/>
-        <location filename="../src/efibooteditor.cpp" line="364"/>
+        <location filename="../src/efibooteditor.cpp" line="372"/>
+        <location filename="../src/efibooteditor.cpp" line="385"/>
         <source>Boot</source>
         <translation>Rozruch</translation>
     </message>
@@ -688,7 +705,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="134"/>
-        <location filename="../src/efibooteditor.cpp" line="354"/>
+        <location filename="../src/efibooteditor.cpp" line="375"/>
         <source>Driver</source>
         <translation>Sterownik</translation>
     </message>
@@ -707,7 +724,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="196"/>
-        <location filename="../src/efibooteditor.cpp" line="357"/>
+        <location filename="../src/efibooteditor.cpp" line="378"/>
         <source>System Preparation</source>
         <translation type="unfinished">System Preparation</translation>
     </message>
@@ -726,7 +743,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="258"/>
-        <location filename="../src/efibooteditor.cpp" line="360"/>
+        <location filename="../src/efibooteditor.cpp" line="381"/>
         <source>Platform Recovery</source>
         <translation type="unfinished">Platform Recovery</translation>
     </message>
@@ -1328,7 +1345,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="1280"/>
-        <location filename="../src/efibooteditor.cpp" line="235"/>
+        <location filename="../src/efibooteditor.cpp" line="238"/>
         <source>About EFI Boot Editor</source>
         <translation>Informajce o EFI Boot Editor</translation>
     </message>
@@ -1398,51 +1415,51 @@
         <translation type="unfinished">Are you sure you want to reorder the boot entries?&lt;br/&gt;All indexes will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="183"/>
+        <location filename="../src/efibooteditor.cpp" line="186"/>
         <source>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</source>
         <translation type="unfinished">Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
         <source>Open boot configuration dump</source>
         <translation type="unfinished">Open boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>JSON documents (*.json)</source>
         <translation type="unfinished">JSON documents (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
         <source>Save boot configuration dump</source>
         <translation type="unfinished">Save boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>Save raw EFI dump</source>
         <translation type="unfinished">Save raw EFI dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="237"/>
+        <location filename="../src/efibooteditor.cpp" line="240"/>
         <source>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</source>
         <extracomment>About dialog</extracomment>
         <translation type="unfinished">&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="245"/>
+        <location filename="../src/efibooteditor.cpp" line="248"/>
         <source>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</source>
         <extracomment>About dialog details</extracomment>
         <translation type="unfinished">&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="297"/>
+        <location filename="../src/efibooteditor.cpp" line="300"/>
         <source>Reorder %1 entries</source>
         <translation type="unfinished">Reorder %1 entries</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="393"/>
+        <location filename="../src/efibooteditor.cpp" line="414"/>
         <source>Are you sure you want to quit?</source>
         <translation type="unfinished">Are you sure you want to quit?</translation>
     </message>
@@ -2491,8 +2508,8 @@
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unknown data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/filepathdialog.cpp" line="571"/>
-        <location filename="../src/filepathdialog.cpp" line="620"/>
+        <location filename="../src/filepathdialog.cpp" line="565"/>
+        <location filename="../src/filepathdialog.cpp" line="607"/>
         <source>Couldn&apos;t change Vendor data format!</source>
         <translation type="unfinished">Couldn&apos;t change Vendor data format!</translation>
     </message>

--- a/translations/efibooteditor_sk.ts
+++ b/translations/efibooteditor_sk.ts
@@ -4,37 +4,37 @@
 <context>
     <name>BootEntryForm</name>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="67"/>
-        <location filename="../src/form/bootentryform.ui" line="70"/>
-        <location filename="../src/form/bootentryform.ui" line="73"/>
-        <location filename="../src/form/bootentryform.ui" line="80"/>
-        <location filename="../src/form/bootentryform.ui" line="83"/>
+        <location filename="../src/form/bootentryform.ui" line="105"/>
+        <location filename="../src/form/bootentryform.ui" line="108"/>
+        <location filename="../src/form/bootentryform.ui" line="111"/>
+        <location filename="../src/form/bootentryform.ui" line="118"/>
+        <location filename="../src/form/bootentryform.ui" line="121"/>
         <source>Description</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="96"/>
-        <location filename="../src/form/bootentryform.ui" line="99"/>
-        <location filename="../src/form/bootentryform.ui" line="102"/>
+        <location filename="../src/form/bootentryform.ui" line="134"/>
+        <location filename="../src/form/bootentryform.ui" line="137"/>
+        <location filename="../src/form/bootentryform.ui" line="140"/>
         <source>Path</source>
         <translation>Cesta</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="318"/>
-        <location filename="../src/form/bootentryform.ui" line="321"/>
-        <location filename="../src/form/bootentryform.ui" line="381"/>
-        <location filename="../src/form/bootentryform.ui" line="384"/>
+        <location filename="../src/form/bootentryform.ui" line="356"/>
+        <location filename="../src/form/bootentryform.ui" line="359"/>
+        <location filename="../src/form/bootentryform.ui" line="419"/>
+        <location filename="../src/form/bootentryform.ui" line="422"/>
         <source>Optional data</source>
         <translation>Nepovinné údaje</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="324"/>
+        <location filename="../src/form/bootentryform.ui" line="362"/>
         <source>Optional</source>
         <translation>Voliteľné</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="337"/>
-        <location filename="../src/form/bootentryform.ui" line="340"/>
+        <location filename="../src/form/bootentryform.ui" line="375"/>
+        <location filename="../src/form/bootentryform.ui" line="378"/>
         <source>Optional data format</source>
         <translation>Voliteľný formát údajov</translation>
     </message>
@@ -44,189 +44,206 @@
         <translation>Bootovací formulár</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="24"/>
+        <location filename="../src/form/bootentryform.ui" line="27"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="40"/>
+        <location filename="../src/form/bootentryform.ui" line="43"/>
+        <source>Error note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="46"/>
+        <source>This entry placeholder is shown here to indicate it&apos;s referenced in boot order. It won&apos;t be modified on save, just left as is.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zadať popis.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="120"/>
-        <location filename="../src/form/bootentryform.ui" line="123"/>
+        <location filename="../src/form/bootentryform.ui" line="158"/>
+        <location filename="../src/form/bootentryform.ui" line="161"/>
         <source>Device path</source>
         <translation>Cesta k zariadeniu</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="126"/>
+        <location filename="../src/form/bootentryform.ui" line="164"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cesta k zariadeniu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="178"/>
-        <location filename="../src/form/bootentryform.ui" line="181"/>
+        <location filename="../src/form/bootentryform.ui" line="216"/>
+        <location filename="../src/form/bootentryform.ui" line="219"/>
         <source>Move file path up</source>
         <translation>Presunúť cestu k súboru hore</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="184"/>
+        <location filename="../src/form/bootentryform.ui" line="222"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Presunúť cestu k súboru hore.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="204"/>
-        <location filename="../src/form/bootentryform.ui" line="207"/>
+        <location filename="../src/form/bootentryform.ui" line="242"/>
+        <location filename="../src/form/bootentryform.ui" line="245"/>
         <source>Move file path down</source>
         <translation>Presunúť cestu k súboru dole</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="210"/>
+        <location filename="../src/form/bootentryform.ui" line="248"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Presunúť cestu k súboru dole.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="230"/>
-        <location filename="../src/form/bootentryform.ui" line="233"/>
+        <location filename="../src/form/bootentryform.ui" line="268"/>
+        <location filename="../src/form/bootentryform.ui" line="271"/>
         <source>Remove file path</source>
         <translation>Odstrániť cestu k súboru</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="236"/>
+        <location filename="../src/form/bootentryform.ui" line="274"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Odstrániť cestu k súboru.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="256"/>
-        <location filename="../src/form/bootentryform.ui" line="259"/>
+        <location filename="../src/form/bootentryform.ui" line="294"/>
+        <location filename="../src/form/bootentryform.ui" line="297"/>
         <source>Edit file path</source>
         <translation>Upraviť cestu k súboru</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="262"/>
+        <location filename="../src/form/bootentryform.ui" line="300"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Upraviť cestu k súboru.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="282"/>
-        <location filename="../src/form/bootentryform.ui" line="285"/>
+        <location filename="../src/form/bootentryform.ui" line="320"/>
+        <location filename="../src/form/bootentryform.ui" line="323"/>
         <source>Add file path</source>
         <translation>Pridať cestu k súboru</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="288"/>
+        <location filename="../src/form/bootentryform.ui" line="326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pridať cestu k súboru.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="343"/>
+        <location filename="../src/form/bootentryform.ui" line="381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Voliteľný formát údajov.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="347"/>
+        <location filename="../src/form/bootentryform.ui" line="385"/>
         <source>BASE64</source>
         <translation>BASE64</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="352"/>
+        <location filename="../src/form/bootentryform.ui" line="390"/>
         <source>UTF-16</source>
         <translation>UTF-16</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="357"/>
+        <location filename="../src/form/bootentryform.ui" line="395"/>
         <source>UTF-8</source>
         <translation>UTF-8</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="362"/>
+        <location filename="../src/form/bootentryform.ui" line="400"/>
         <source>HEX</source>
         <translation>HEX</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="387"/>
+        <location filename="../src/form/bootentryform.ui" line="425"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zadať nepovinné údaje.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="400"/>
-        <location filename="../src/form/bootentryform.ui" line="403"/>
-        <location filename="../src/form/bootentryform.ui" line="406"/>
+        <location filename="../src/form/bootentryform.ui" line="438"/>
+        <location filename="../src/form/bootentryform.ui" line="441"/>
+        <location filename="../src/form/bootentryform.ui" line="444"/>
         <source>Attributes</source>
         <translation>Atribúty</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="526"/>
+        <location filename="../src/form/bootentryform.ui" line="564"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zadať kategóriu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="54"/>
+        <location filename="../src/form/bootentryform.ui" line="92"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zadať index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="443"/>
+        <location filename="../src/form/bootentryform.ui" line="481"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Zvažuje sa automatické spustenie?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="472"/>
+        <location filename="../src/form/bootentryform.ui" line="510"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skryté.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="488"/>
+        <location filename="../src/form/bootentryform.ui" line="526"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vynútiť opätovné pripojenie.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="437"/>
-        <location filename="../src/form/bootentryform.ui" line="440"/>
-        <location filename="../src/form/bootentryform.ui" line="446"/>
+        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="478"/>
+        <location filename="../src/form/bootentryform.ui" line="484"/>
         <source>Active</source>
         <translation>Aktívne</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="482"/>
-        <location filename="../src/form/bootentryform.ui" line="485"/>
-        <location filename="../src/form/bootentryform.ui" line="491"/>
+        <location filename="../src/form/bootentryform.ui" line="520"/>
+        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="529"/>
         <source>Force reconnect</source>
         <translation>Vynútiť opätovné pripojenie</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="466"/>
-        <location filename="../src/form/bootentryform.ui" line="469"/>
-        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="504"/>
+        <location filename="../src/form/bootentryform.ui" line="507"/>
+        <location filename="../src/form/bootentryform.ui" line="513"/>
         <source>Hidden</source>
         <translation>Skryté</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="501"/>
-        <location filename="../src/form/bootentryform.ui" line="504"/>
-        <location filename="../src/form/bootentryform.ui" line="507"/>
-        <location filename="../src/form/bootentryform.ui" line="520"/>
-        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="539"/>
+        <location filename="../src/form/bootentryform.ui" line="542"/>
+        <location filename="../src/form/bootentryform.ui" line="545"/>
+        <location filename="../src/form/bootentryform.ui" line="558"/>
+        <location filename="../src/form/bootentryform.ui" line="561"/>
         <source>Category</source>
         <translation>Kategória</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="530"/>
+        <location filename="../src/form/bootentryform.ui" line="568"/>
         <source>Boot</source>
         <translation>Spúšťacie</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="535"/>
+        <location filename="../src/form/bootentryform.ui" line="573"/>
         <source>App</source>
         <translation>Aplikácia</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="30"/>
-        <location filename="../src/form/bootentryform.ui" line="33"/>
-        <location filename="../src/form/bootentryform.ui" line="36"/>
-        <location filename="../src/form/bootentryform.ui" line="48"/>
-        <location filename="../src/form/bootentryform.ui" line="51"/>
+        <location filename="../src/form/bootentryform.ui" line="68"/>
+        <location filename="../src/form/bootentryform.ui" line="71"/>
+        <location filename="../src/form/bootentryform.ui" line="74"/>
+        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="89"/>
         <source>Index</source>
         <translation>Index</translation>
     </message>
     <message>
-        <location filename="../src/bootentryform.cpp" line="97"/>
+        <location filename="../src/bootentryform.cpp" line="103"/>
         <source>Couldn&apos;t change optional data format!</source>
         <translation>Nepodarilo sa zmeniť voliteľný formát údajov!</translation>
     </message>
@@ -353,28 +370,28 @@
 <context>
     <name>EFIBootData</name>
     <message>
-        <location filename="../src/efibootdata.cpp" line="93"/>
-        <location filename="../src/efibootdata.cpp" line="583"/>
-        <location filename="../src/efibootdata.cpp" line="772"/>
-        <location filename="../src/efibootdata.cpp" line="1026"/>
-        <location filename="../src/efibootdata.cpp" line="1132"/>
+        <location filename="../src/efibootdata.cpp" line="97"/>
+        <location filename="../src/efibootdata.cpp" line="622"/>
+        <location filename="../src/efibootdata.cpp" line="812"/>
+        <location filename="../src/efibootdata.cpp" line="1067"/>
+        <location filename="../src/efibootdata.cpp" line="1173"/>
         <source>%1: not found</source>
         <translation>%1: nenájdené</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="102"/>
-        <location filename="../src/efibootdata.cpp" line="592"/>
-        <location filename="../src/efibootdata.cpp" line="1052"/>
+        <location filename="../src/efibootdata.cpp" line="106"/>
+        <location filename="../src/efibootdata.cpp" line="631"/>
+        <location filename="../src/efibootdata.cpp" line="1093"/>
         <source>%1: failed deserialization</source>
         <translation>%1: neúspešná deserializácia</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Error loading entries</source>
         <translation>Chyba pri načítaní záznamov</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Failed to load some EFI Boot Manager entries:
 
   - %1</source>
@@ -383,79 +400,79 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Error saving entries</source>
         <translation>Chyba pri ukladaní záznamov</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Entry %1(%2): duplicated index!</source>
         <translation>Záznam %1(%2): duplikovaný index!</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="289"/>
-        <location filename="../src/efibootdata.cpp" line="322"/>
-        <location filename="../src/efibootdata.cpp" line="332"/>
-        <location filename="../src/efibootdata.cpp" line="340"/>
-        <location filename="../src/efibootdata.cpp" line="347"/>
-        <location filename="../src/efibootdata.cpp" line="366"/>
+        <location filename="../src/efibootdata.cpp" line="330"/>
+        <location filename="../src/efibootdata.cpp" line="360"/>
+        <location filename="../src/efibootdata.cpp" line="370"/>
+        <location filename="../src/efibootdata.cpp" line="378"/>
+        <location filename="../src/efibootdata.cpp" line="385"/>
+        <location filename="../src/efibootdata.cpp" line="404"/>
         <source>Error saving %1</source>
         <translation>Chyba pri ukladaní %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="302"/>
-        <location filename="../src/efibootdata.cpp" line="313"/>
-        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="340"/>
+        <location filename="../src/efibootdata.cpp" line="351"/>
+        <location filename="../src/efibootdata.cpp" line="395"/>
         <source>Error removing %1</source>
         <translation>Chyba pri odstraňovaní %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="399"/>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Error importing boot configuration</source>
         <translation>Chyba pri importovaní spúšťacej konfigurácie</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="555"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
         <source>Couldn&apos;t open selected file (%1).</source>
         <translation>Vybraný súbor sa nepodarilo otvoriť (%1).</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="399"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
         <source>Invalid _Type: %1</source>
         <translation>Neplatný _Type: %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
-        <location filename="../src/efibootdata.cpp" line="540"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
         <source>Error exporting boot configuration</source>
         <translation>Chyba pri exportovaní spúšťacej konfigurácie</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
         <source>Couldn&apos;t open selected file (%1): %2.</source>
         <translation>Vybraný súbor sa nepodarilo otvoriť (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="540"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
         <source>Couldn&apos;t write into file (%1): %2.</source>
         <translation>Nepodaril sa zápis do súboru (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="555"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Error dumping raw EFI data</source>
         <translation>Chyba výpisu nespracovaných dát EFI</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Failed to dump some EFI Boot Manager entries:
 
   - %1</source>
@@ -464,17 +481,17 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="660"/>
+        <location filename="../src/efibootdata.cpp" line="699"/>
         <source>Timeout</source>
         <translation>Časový limit</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="676"/>
+        <location filename="../src/efibootdata.cpp" line="715"/>
         <source>Apple boot-args</source>
         <translation>Argumenty spúšťania Apple</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="692"/>
+        <location filename="../src/efibootdata.cpp" line="731"/>
         <source>Firmware actions</source>
         <translation>Akcie firmvéru</translation>
     </message>
@@ -484,147 +501,147 @@
         <translation>Načítanie položiek EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="81"/>
-        <location filename="../src/efibootdata.cpp" line="568"/>
+        <location filename="../src/efibootdata.cpp" line="85"/>
+        <location filename="../src/efibootdata.cpp" line="607"/>
         <source>Searching EFI Boot Manager entries…</source>
         <translation>Vyhľadávanie položiek EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="98"/>
+        <location filename="../src/efibootdata.cpp" line="102"/>
         <source>Processing EFI Boot Manager entries (%1)…</source>
         <translation>Spracovanie položiek EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="234"/>
+        <location filename="../src/efibootdata.cpp" line="262"/>
         <source>Saving EFI Boot Manager entries…</source>
         <translation>Ukladanie položiek EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="244"/>
+        <location filename="../src/efibootdata.cpp" line="282"/>
         <source>Searching old EFI Boot Manager entries…</source>
         <translation>Vyhľadávanie starých položiek EFI Boot Manager…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="274"/>
-        <location filename="../src/efibootdata.cpp" line="319"/>
-        <location filename="../src/efibootdata.cpp" line="329"/>
-        <location filename="../src/efibootdata.cpp" line="337"/>
-        <location filename="../src/efibootdata.cpp" line="344"/>
-        <location filename="../src/efibootdata.cpp" line="363"/>
+        <location filename="../src/efibootdata.cpp" line="312"/>
+        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="367"/>
+        <location filename="../src/efibootdata.cpp" line="375"/>
+        <location filename="../src/efibootdata.cpp" line="382"/>
+        <location filename="../src/efibootdata.cpp" line="401"/>
         <source>Saving EFI Boot Manager entries (%1)…</source>
         <translation>Ukladanie položiek EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="299"/>
+        <location filename="../src/efibootdata.cpp" line="337"/>
         <source>Removing old EFI Boot Manager entries (%1)…</source>
         <translation>Odstraňovanie starých položiek EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="310"/>
-        <location filename="../src/efibootdata.cpp" line="354"/>
+        <location filename="../src/efibootdata.cpp" line="348"/>
+        <location filename="../src/efibootdata.cpp" line="392"/>
         <source>Removing EFI Boot Manager entries (%1)…</source>
         <translation>Odstraňovanie položiek EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="379"/>
-        <location filename="../src/efibootdata.cpp" line="759"/>
-        <location filename="../src/efibootdata.cpp" line="1013"/>
+        <location filename="../src/efibootdata.cpp" line="417"/>
+        <location filename="../src/efibootdata.cpp" line="798"/>
+        <location filename="../src/efibootdata.cpp" line="1053"/>
         <source>Importing boot configuration…</source>
         <translation>Importovanie spúšťacej konfigurácie…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="408"/>
-        <location filename="../src/efibootdata.cpp" line="551"/>
+        <location filename="../src/efibootdata.cpp" line="446"/>
+        <location filename="../src/efibootdata.cpp" line="590"/>
         <source>Exporting boot configuration…</source>
         <translation>Exportovanie spúšťacej konfigurácie…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="457"/>
-        <location filename="../src/efibootdata.cpp" line="588"/>
+        <location filename="../src/efibootdata.cpp" line="495"/>
+        <location filename="../src/efibootdata.cpp" line="627"/>
         <source>Exporting EFI Boot Manager entries (%1)…</source>
         <translation>Exportovanie položiek EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="777"/>
-        <location filename="../src/efibootdata.cpp" line="1031"/>
+        <location filename="../src/efibootdata.cpp" line="817"/>
+        <location filename="../src/efibootdata.cpp" line="1072"/>
         <source>Importing EFI Boot Manager entries (%1)…</source>
         <translation>Importovanie položiek EFI Boot Manager (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="780"/>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1041"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="820"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1082"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>%1: %2 expected</source>
         <translation>%1: očakáva sa %2</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="788"/>
-        <location filename="../src/efibootdata.cpp" line="793"/>
-        <location filename="../src/efibootdata.cpp" line="798"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
+        <location filename="../src/efibootdata.cpp" line="828"/>
+        <location filename="../src/efibootdata.cpp" line="833"/>
+        <location filename="../src/efibootdata.cpp" line="838"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
         <source>number</source>
         <translation>číslo</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="803"/>
-        <location filename="../src/efibootdata.cpp" line="808"/>
-        <location filename="../src/efibootdata.cpp" line="813"/>
-        <location filename="../src/efibootdata.cpp" line="818"/>
-        <location filename="../src/efibootdata.cpp" line="823"/>
+        <location filename="../src/efibootdata.cpp" line="843"/>
+        <location filename="../src/efibootdata.cpp" line="848"/>
+        <location filename="../src/efibootdata.cpp" line="853"/>
+        <location filename="../src/efibootdata.cpp" line="858"/>
+        <location filename="../src/efibootdata.cpp" line="863"/>
         <source>bool</source>
         <translation>bool</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="828"/>
-        <location filename="../src/efibootdata.cpp" line="872"/>
-        <location filename="../src/efibootdata.cpp" line="918"/>
+        <location filename="../src/efibootdata.cpp" line="868"/>
+        <location filename="../src/efibootdata.cpp" line="912"/>
+        <location filename="../src/efibootdata.cpp" line="958"/>
         <source>array</source>
         <translation>pole</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="999"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="1039"/>
         <source>string</source>
         <translation>reťazec</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="862"/>
-        <location filename="../src/efibootdata.cpp" line="898"/>
+        <location filename="../src/efibootdata.cpp" line="902"/>
+        <location filename="../src/efibootdata.cpp" line="938"/>
         <source>%1: unknown os indication</source>
         <translation>%1: neznáma indikácia os</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="941"/>
-        <location filename="../src/efibootdata.cpp" line="969"/>
-        <location filename="../src/efibootdata.cpp" line="994"/>
+        <location filename="../src/efibootdata.cpp" line="981"/>
+        <location filename="../src/efibootdata.cpp" line="1009"/>
         <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>object</source>
         <translation>objekt</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
         <source>hexadecimal number</source>
         <translation>hexadecimálne číslo</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="975"/>
+        <location filename="../src/efibootdata.cpp" line="1015"/>
         <source>%1: failed parsing</source>
         <translation>%1: neúspešná analýza</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Failed to import some EFI Boot Manager entries:
 
   - %1</source>
@@ -633,7 +650,7 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1044"/>
+        <location filename="../src/efibootdata.cpp" line="1085"/>
         <source>object(raw_data: string, efi_attributes: number)</source>
         <extracomment>Expected JSON structure, thrown as error description. raw_data and efi_attributes are field names in JSON file</extracomment>
         <translation>object(raw_data: string, efi_attributes: number)</translation>
@@ -668,8 +685,8 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="72"/>
-        <location filename="../src/efibooteditor.cpp" line="351"/>
-        <location filename="../src/efibooteditor.cpp" line="364"/>
+        <location filename="../src/efibooteditor.cpp" line="372"/>
+        <location filename="../src/efibooteditor.cpp" line="385"/>
         <source>Boot</source>
         <translation>Boot</translation>
     </message>
@@ -688,7 +705,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="134"/>
-        <location filename="../src/efibooteditor.cpp" line="354"/>
+        <location filename="../src/efibooteditor.cpp" line="375"/>
         <source>Driver</source>
         <translation>Ovládač</translation>
     </message>
@@ -707,7 +724,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="196"/>
-        <location filename="../src/efibooteditor.cpp" line="357"/>
+        <location filename="../src/efibooteditor.cpp" line="378"/>
         <source>System Preparation</source>
         <translation>Príprava systému</translation>
     </message>
@@ -726,7 +743,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="258"/>
-        <location filename="../src/efibooteditor.cpp" line="360"/>
+        <location filename="../src/efibooteditor.cpp" line="381"/>
         <source>Platform Recovery</source>
         <translation>Obnova platformy</translation>
     </message>
@@ -1328,7 +1345,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="1280"/>
-        <location filename="../src/efibooteditor.cpp" line="235"/>
+        <location filename="../src/efibooteditor.cpp" line="238"/>
         <source>About EFI Boot Editor</source>
         <translation>O aplikácii EFI Boot Editor</translation>
     </message>
@@ -1398,51 +1415,51 @@
         <translation>Chcete zmeniť poradie spúšťacích položiek?&lt;br/&gt;Všetky indexy budú prepísané!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="183"/>
+        <location filename="../src/efibooteditor.cpp" line="186"/>
         <source>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</source>
         <translation>Chcete uložiť zmeny?&lt;br/&gt;Vaša konfigurácia EFI bude prepísaná!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
         <source>Open boot configuration dump</source>
         <translation>Otvoriť výpis konfigurácie spúšťania</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>JSON documents (*.json)</source>
         <translation>Dokumenty JSON (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
         <source>Save boot configuration dump</source>
         <translation>Uloženie výpisu konfigurácie spúšťania</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>Save raw EFI dump</source>
         <translation>Uložiť nespracované údaje EFI</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="237"/>
+        <location filename="../src/efibooteditor.cpp" line="240"/>
         <source>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</source>
         <extracomment>About dialog</extracomment>
         <translation>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Verzia &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor pre systémy založené na (U)EFI.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="245"/>
+        <location filename="../src/efibooteditor.cpp" line="248"/>
         <source>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</source>
         <extracomment>About dialog details</extracomment>
         <translation>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Webstránka&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Program sa poskytuje TAK AKO JE, bez ŽIADNEJ ZÁRUKY, VRÁTANE ZÁRUKY NA DIZAJN, PREDAJNOSTI A VHODNOSTI NA KONKRÉTNY ÚČEL.&lt;/p&gt;&lt;p&gt;Licencia: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL verzia 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Pre systém Linux používa &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; pre prístup k premenným EFI.&lt;/p&gt;&lt;p&gt;Použité ikony Tango ako rezervné ikony.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="297"/>
+        <location filename="../src/efibooteditor.cpp" line="300"/>
         <source>Reorder %1 entries</source>
         <translation>Zmena poradia položiek %1</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="393"/>
+        <location filename="../src/efibooteditor.cpp" line="414"/>
         <source>Are you sure you want to quit?</source>
         <translation>Ste si istý, že chcete skončiť?</translation>
     </message>
@@ -2491,8 +2508,8 @@
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Neznáme údaje.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/filepathdialog.cpp" line="571"/>
-        <location filename="../src/filepathdialog.cpp" line="620"/>
+        <location filename="../src/filepathdialog.cpp" line="565"/>
+        <location filename="../src/filepathdialog.cpp" line="607"/>
         <source>Couldn&apos;t change Vendor data format!</source>
         <translation>Nepodarilo sa zmeniť formát dát predajcu!</translation>
     </message>

--- a/translations/efibooteditor_sl.ts
+++ b/translations/efibooteditor_sl.ts
@@ -4,37 +4,37 @@
 <context>
     <name>BootEntryForm</name>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="67"/>
-        <location filename="../src/form/bootentryform.ui" line="70"/>
-        <location filename="../src/form/bootentryform.ui" line="73"/>
-        <location filename="../src/form/bootentryform.ui" line="80"/>
-        <location filename="../src/form/bootentryform.ui" line="83"/>
+        <location filename="../src/form/bootentryform.ui" line="105"/>
+        <location filename="../src/form/bootentryform.ui" line="108"/>
+        <location filename="../src/form/bootentryform.ui" line="111"/>
+        <location filename="../src/form/bootentryform.ui" line="118"/>
+        <location filename="../src/form/bootentryform.ui" line="121"/>
         <source>Description</source>
         <translation>Opis</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="96"/>
-        <location filename="../src/form/bootentryform.ui" line="99"/>
-        <location filename="../src/form/bootentryform.ui" line="102"/>
+        <location filename="../src/form/bootentryform.ui" line="134"/>
+        <location filename="../src/form/bootentryform.ui" line="137"/>
+        <location filename="../src/form/bootentryform.ui" line="140"/>
         <source>Path</source>
         <translation>Pot</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="318"/>
-        <location filename="../src/form/bootentryform.ui" line="321"/>
-        <location filename="../src/form/bootentryform.ui" line="381"/>
-        <location filename="../src/form/bootentryform.ui" line="384"/>
+        <location filename="../src/form/bootentryform.ui" line="356"/>
+        <location filename="../src/form/bootentryform.ui" line="359"/>
+        <location filename="../src/form/bootentryform.ui" line="419"/>
+        <location filename="../src/form/bootentryform.ui" line="422"/>
         <source>Optional data</source>
         <translation>Neobvezni podatki</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="324"/>
+        <location filename="../src/form/bootentryform.ui" line="362"/>
         <source>Optional</source>
         <translation>Neobvezno</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="337"/>
-        <location filename="../src/form/bootentryform.ui" line="340"/>
+        <location filename="../src/form/bootentryform.ui" line="375"/>
+        <location filename="../src/form/bootentryform.ui" line="378"/>
         <source>Optional data format</source>
         <translation>Format neobveznih podatkov</translation>
     </message>
@@ -44,189 +44,206 @@
         <translation>Obrazec zagonskega vnosa</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="24"/>
+        <location filename="../src/form/bootentryform.ui" line="27"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="40"/>
+        <location filename="../src/form/bootentryform.ui" line="43"/>
+        <source>Error note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="46"/>
+        <source>This entry placeholder is shown here to indicate it&apos;s referenced in boot order. It won&apos;t be modified on save, just left as is.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/form/bootentryform.ui" line="124"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry description.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Opis vnosa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="120"/>
-        <location filename="../src/form/bootentryform.ui" line="123"/>
+        <location filename="../src/form/bootentryform.ui" line="158"/>
+        <location filename="../src/form/bootentryform.ui" line="161"/>
         <source>Device path</source>
         <translation>Pot naprave</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="126"/>
+        <location filename="../src/form/bootentryform.ui" line="164"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Device path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pot naprave.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="178"/>
-        <location filename="../src/form/bootentryform.ui" line="181"/>
+        <location filename="../src/form/bootentryform.ui" line="216"/>
+        <location filename="../src/form/bootentryform.ui" line="219"/>
         <source>Move file path up</source>
         <translation>Premakni pot datoteke navzgor</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="184"/>
+        <location filename="../src/form/bootentryform.ui" line="222"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path up.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Premakni pot datoteke navzgor.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="204"/>
-        <location filename="../src/form/bootentryform.ui" line="207"/>
+        <location filename="../src/form/bootentryform.ui" line="242"/>
+        <location filename="../src/form/bootentryform.ui" line="245"/>
         <source>Move file path down</source>
         <translation>Premakni pot datoteke navzdol</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="210"/>
+        <location filename="../src/form/bootentryform.ui" line="248"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Move file path down.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Premakni pot datoteke navzdol.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="230"/>
-        <location filename="../src/form/bootentryform.ui" line="233"/>
+        <location filename="../src/form/bootentryform.ui" line="268"/>
+        <location filename="../src/form/bootentryform.ui" line="271"/>
         <source>Remove file path</source>
         <translation>Odstrani pot datoteke</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="236"/>
+        <location filename="../src/form/bootentryform.ui" line="274"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Odstrani pot datoteke.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="256"/>
-        <location filename="../src/form/bootentryform.ui" line="259"/>
+        <location filename="../src/form/bootentryform.ui" line="294"/>
+        <location filename="../src/form/bootentryform.ui" line="297"/>
         <source>Edit file path</source>
         <translation>Uredi pot datoteke</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="262"/>
+        <location filename="../src/form/bootentryform.ui" line="300"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Uredi pot datoteke.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="282"/>
-        <location filename="../src/form/bootentryform.ui" line="285"/>
+        <location filename="../src/form/bootentryform.ui" line="320"/>
+        <location filename="../src/form/bootentryform.ui" line="323"/>
         <source>Add file path</source>
         <translation>Dodaj pot datoteke</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="288"/>
+        <location filename="../src/form/bootentryform.ui" line="326"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add file path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dodaj pot datoteke.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="343"/>
+        <location filename="../src/form/bootentryform.ui" line="381"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional data format.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Format neobveznih podatkov.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="347"/>
+        <location filename="../src/form/bootentryform.ui" line="385"/>
         <source>BASE64</source>
         <translation>BASE64</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="352"/>
+        <location filename="../src/form/bootentryform.ui" line="390"/>
         <source>UTF-16</source>
         <translation>UTF-16</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="357"/>
+        <location filename="../src/form/bootentryform.ui" line="395"/>
         <source>UTF-8</source>
         <translation>UTF-8</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="362"/>
+        <location filename="../src/form/bootentryform.ui" line="400"/>
         <source>HEX</source>
         <translation>16-tiško</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="387"/>
+        <location filename="../src/form/bootentryform.ui" line="425"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry optional data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Vnos neobveznih podatkov.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="400"/>
-        <location filename="../src/form/bootentryform.ui" line="403"/>
-        <location filename="../src/form/bootentryform.ui" line="406"/>
+        <location filename="../src/form/bootentryform.ui" line="438"/>
+        <location filename="../src/form/bootentryform.ui" line="441"/>
+        <location filename="../src/form/bootentryform.ui" line="444"/>
         <source>Attributes</source>
         <translation>Atributi</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="526"/>
+        <location filename="../src/form/bootentryform.ui" line="564"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry category.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kategorija vnosa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="54"/>
+        <location filename="../src/form/bootentryform.ui" line="92"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Entry index.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indeks vnosa.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="443"/>
+        <location filename="../src/form/bootentryform.ui" line="481"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Is entry considered for automatic boot?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ali se vnos upošteva za samodejni zagon?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="472"/>
+        <location filename="../src/form/bootentryform.ui" line="510"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hidden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skrit.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="488"/>
+        <location filename="../src/form/bootentryform.ui" line="526"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force reconnect.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prisilno znova poveži.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="437"/>
-        <location filename="../src/form/bootentryform.ui" line="440"/>
-        <location filename="../src/form/bootentryform.ui" line="446"/>
+        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="478"/>
+        <location filename="../src/form/bootentryform.ui" line="484"/>
         <source>Active</source>
         <translation>Aktiven</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="482"/>
-        <location filename="../src/form/bootentryform.ui" line="485"/>
-        <location filename="../src/form/bootentryform.ui" line="491"/>
+        <location filename="../src/form/bootentryform.ui" line="520"/>
+        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="529"/>
         <source>Force reconnect</source>
         <translation>Prisilno znova poveži</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="466"/>
-        <location filename="../src/form/bootentryform.ui" line="469"/>
-        <location filename="../src/form/bootentryform.ui" line="475"/>
+        <location filename="../src/form/bootentryform.ui" line="504"/>
+        <location filename="../src/form/bootentryform.ui" line="507"/>
+        <location filename="../src/form/bootentryform.ui" line="513"/>
         <source>Hidden</source>
         <translation>Skrit</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="501"/>
-        <location filename="../src/form/bootentryform.ui" line="504"/>
-        <location filename="../src/form/bootentryform.ui" line="507"/>
-        <location filename="../src/form/bootentryform.ui" line="520"/>
-        <location filename="../src/form/bootentryform.ui" line="523"/>
+        <location filename="../src/form/bootentryform.ui" line="539"/>
+        <location filename="../src/form/bootentryform.ui" line="542"/>
+        <location filename="../src/form/bootentryform.ui" line="545"/>
+        <location filename="../src/form/bootentryform.ui" line="558"/>
+        <location filename="../src/form/bootentryform.ui" line="561"/>
         <source>Category</source>
         <translation>Kategorija</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="530"/>
+        <location filename="../src/form/bootentryform.ui" line="568"/>
         <source>Boot</source>
         <translation>Zagon</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="535"/>
+        <location filename="../src/form/bootentryform.ui" line="573"/>
         <source>App</source>
         <translation>Aplikacija</translation>
     </message>
     <message>
-        <location filename="../src/form/bootentryform.ui" line="30"/>
-        <location filename="../src/form/bootentryform.ui" line="33"/>
-        <location filename="../src/form/bootentryform.ui" line="36"/>
-        <location filename="../src/form/bootentryform.ui" line="48"/>
-        <location filename="../src/form/bootentryform.ui" line="51"/>
+        <location filename="../src/form/bootentryform.ui" line="68"/>
+        <location filename="../src/form/bootentryform.ui" line="71"/>
+        <location filename="../src/form/bootentryform.ui" line="74"/>
+        <location filename="../src/form/bootentryform.ui" line="86"/>
+        <location filename="../src/form/bootentryform.ui" line="89"/>
         <source>Index</source>
         <translation>Indeks</translation>
     </message>
     <message>
-        <location filename="../src/bootentryform.cpp" line="97"/>
+        <location filename="../src/bootentryform.cpp" line="103"/>
         <source>Couldn&apos;t change optional data format!</source>
         <translation>Formata neobveznih podatkov ni bilo mogoče spremeniti!</translation>
     </message>
@@ -353,28 +370,28 @@
 <context>
     <name>EFIBootData</name>
     <message>
-        <location filename="../src/efibootdata.cpp" line="93"/>
-        <location filename="../src/efibootdata.cpp" line="583"/>
-        <location filename="../src/efibootdata.cpp" line="772"/>
-        <location filename="../src/efibootdata.cpp" line="1026"/>
-        <location filename="../src/efibootdata.cpp" line="1132"/>
+        <location filename="../src/efibootdata.cpp" line="97"/>
+        <location filename="../src/efibootdata.cpp" line="622"/>
+        <location filename="../src/efibootdata.cpp" line="812"/>
+        <location filename="../src/efibootdata.cpp" line="1067"/>
+        <location filename="../src/efibootdata.cpp" line="1173"/>
         <source>%1: not found</source>
         <translation>%1: ni bilo mogoče najti</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="102"/>
-        <location filename="../src/efibootdata.cpp" line="592"/>
-        <location filename="../src/efibootdata.cpp" line="1052"/>
+        <location filename="../src/efibootdata.cpp" line="106"/>
+        <location filename="../src/efibootdata.cpp" line="631"/>
+        <location filename="../src/efibootdata.cpp" line="1093"/>
         <source>%1: failed deserialization</source>
         <translation>%1: neuspešna deserializacija</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Error loading entries</source>
         <translation>Napaka pri nalaganju vnosov</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="227"/>
+        <location filename="../src/efibootdata.cpp" line="255"/>
         <source>Failed to load some EFI Boot Manager entries:
 
   - %1</source>
@@ -383,79 +400,79 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Error saving entries</source>
         <translation>Napaka pri shranjevanju vnosov</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="269"/>
-        <location filename="../src/efibootdata.cpp" line="439"/>
+        <location filename="../src/efibootdata.cpp" line="307"/>
+        <location filename="../src/efibootdata.cpp" line="477"/>
         <source>Entry %1(%2): duplicated index!</source>
         <translation>Napaka %1(%2): podvojen indeks!</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="289"/>
-        <location filename="../src/efibootdata.cpp" line="322"/>
-        <location filename="../src/efibootdata.cpp" line="332"/>
-        <location filename="../src/efibootdata.cpp" line="340"/>
-        <location filename="../src/efibootdata.cpp" line="347"/>
-        <location filename="../src/efibootdata.cpp" line="366"/>
+        <location filename="../src/efibootdata.cpp" line="330"/>
+        <location filename="../src/efibootdata.cpp" line="360"/>
+        <location filename="../src/efibootdata.cpp" line="370"/>
+        <location filename="../src/efibootdata.cpp" line="378"/>
+        <location filename="../src/efibootdata.cpp" line="385"/>
+        <location filename="../src/efibootdata.cpp" line="404"/>
         <source>Error saving %1</source>
         <translation>Napaka pri shranjevanju %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="302"/>
-        <location filename="../src/efibootdata.cpp" line="313"/>
-        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="340"/>
+        <location filename="../src/efibootdata.cpp" line="351"/>
+        <location filename="../src/efibootdata.cpp" line="395"/>
         <source>Error removing %1</source>
         <translation>Napaka pri odstranjevanju %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="399"/>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Error importing boot configuration</source>
         <translation>Napaka pri uvozu zagonskih nastavitev</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="383"/>
-        <location filename="../src/efibootdata.cpp" line="555"/>
+        <location filename="../src/efibootdata.cpp" line="421"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
         <source>Couldn&apos;t open selected file (%1).</source>
         <translation>Izbrane datoteke (%1) ni bilo mogoče odpreti.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="399"/>
+        <location filename="../src/efibootdata.cpp" line="437"/>
         <source>Invalid _Type: %1</source>
         <translation>Neveljavna_vrsta: %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
-        <location filename="../src/efibootdata.cpp" line="540"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
         <source>Error exporting boot configuration</source>
         <translation>Napaka pri izvozu zagonskih nastavitev</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="412"/>
+        <location filename="../src/efibootdata.cpp" line="450"/>
         <source>Couldn&apos;t open selected file (%1): %2.</source>
         <translation>Ni bilo mogoče odpreti izbrane datoteke (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="540"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
+        <location filename="../src/efibootdata.cpp" line="579"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
         <source>Couldn&apos;t write into file (%1): %2.</source>
         <translation>Ni bilo mogoče pisati v datoteko (%1): %2.</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="555"/>
-        <location filename="../src/efibootdata.cpp" line="644"/>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="594"/>
+        <location filename="../src/efibootdata.cpp" line="683"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Error dumping raw EFI data</source>
         <translation>Napaka pri izpisu surovih podatkov EFI</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="650"/>
+        <location filename="../src/efibootdata.cpp" line="689"/>
         <source>Failed to dump some EFI Boot Manager entries:
 
   - %1</source>
@@ -464,17 +481,17 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="660"/>
+        <location filename="../src/efibootdata.cpp" line="699"/>
         <source>Timeout</source>
         <translation>Odmor</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="676"/>
+        <location filename="../src/efibootdata.cpp" line="715"/>
         <source>Apple boot-args</source>
         <translation>Apple zagonski argumenti</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="692"/>
+        <location filename="../src/efibootdata.cpp" line="731"/>
         <source>Firmware actions</source>
         <translation>Akcije vdelane programske opreme</translation>
     </message>
@@ -484,147 +501,147 @@
         <translation>Nalaganje vnosov EFI Boot Managerja…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="81"/>
-        <location filename="../src/efibootdata.cpp" line="568"/>
+        <location filename="../src/efibootdata.cpp" line="85"/>
+        <location filename="../src/efibootdata.cpp" line="607"/>
         <source>Searching EFI Boot Manager entries…</source>
         <translation>Iskanje vnosov EFI Boot Managerja…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="98"/>
+        <location filename="../src/efibootdata.cpp" line="102"/>
         <source>Processing EFI Boot Manager entries (%1)…</source>
         <translation>Obdelava vnosov EFI Boot Managerja (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="234"/>
+        <location filename="../src/efibootdata.cpp" line="262"/>
         <source>Saving EFI Boot Manager entries…</source>
         <translation>Shranjevanje vnosov EFI Boot Managerja…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="244"/>
+        <location filename="../src/efibootdata.cpp" line="282"/>
         <source>Searching old EFI Boot Manager entries…</source>
         <translation>Iskanje starih vnosov EFI Boot Managerja…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="274"/>
-        <location filename="../src/efibootdata.cpp" line="319"/>
-        <location filename="../src/efibootdata.cpp" line="329"/>
-        <location filename="../src/efibootdata.cpp" line="337"/>
-        <location filename="../src/efibootdata.cpp" line="344"/>
-        <location filename="../src/efibootdata.cpp" line="363"/>
+        <location filename="../src/efibootdata.cpp" line="312"/>
+        <location filename="../src/efibootdata.cpp" line="357"/>
+        <location filename="../src/efibootdata.cpp" line="367"/>
+        <location filename="../src/efibootdata.cpp" line="375"/>
+        <location filename="../src/efibootdata.cpp" line="382"/>
+        <location filename="../src/efibootdata.cpp" line="401"/>
         <source>Saving EFI Boot Manager entries (%1)…</source>
         <translation>Shranjevanje vnosov EFI Boot Managerja (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="299"/>
+        <location filename="../src/efibootdata.cpp" line="337"/>
         <source>Removing old EFI Boot Manager entries (%1)…</source>
         <translation>Odstranjevanje starih vnosov EFI Boot Managerja (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="310"/>
-        <location filename="../src/efibootdata.cpp" line="354"/>
+        <location filename="../src/efibootdata.cpp" line="348"/>
+        <location filename="../src/efibootdata.cpp" line="392"/>
         <source>Removing EFI Boot Manager entries (%1)…</source>
         <translation>Odstranjevanje vnosov EFI Boot Managerja (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="379"/>
-        <location filename="../src/efibootdata.cpp" line="759"/>
-        <location filename="../src/efibootdata.cpp" line="1013"/>
+        <location filename="../src/efibootdata.cpp" line="417"/>
+        <location filename="../src/efibootdata.cpp" line="798"/>
+        <location filename="../src/efibootdata.cpp" line="1053"/>
         <source>Importing boot configuration…</source>
         <translation>Uvažanje nastavitev zagona…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="408"/>
-        <location filename="../src/efibootdata.cpp" line="551"/>
+        <location filename="../src/efibootdata.cpp" line="446"/>
+        <location filename="../src/efibootdata.cpp" line="590"/>
         <source>Exporting boot configuration…</source>
         <translation>Izvažanje nastavitev zagona…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="457"/>
-        <location filename="../src/efibootdata.cpp" line="588"/>
+        <location filename="../src/efibootdata.cpp" line="495"/>
+        <location filename="../src/efibootdata.cpp" line="627"/>
         <source>Exporting EFI Boot Manager entries (%1)…</source>
         <translation>Izvažanje vnosov EFI Boot Managerja (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="777"/>
-        <location filename="../src/efibootdata.cpp" line="1031"/>
+        <location filename="../src/efibootdata.cpp" line="817"/>
+        <location filename="../src/efibootdata.cpp" line="1072"/>
         <source>Importing EFI Boot Manager entries (%1)…</source>
         <translation>Uvažanje vnosov EFI Boot Managerja (%1)…</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="780"/>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1041"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="820"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1082"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>%1: %2 expected</source>
         <translation>%1: %2 je pričakovano</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="788"/>
-        <location filename="../src/efibootdata.cpp" line="793"/>
-        <location filename="../src/efibootdata.cpp" line="798"/>
-        <location filename="../src/efibootdata.cpp" line="929"/>
+        <location filename="../src/efibootdata.cpp" line="828"/>
+        <location filename="../src/efibootdata.cpp" line="833"/>
+        <location filename="../src/efibootdata.cpp" line="838"/>
+        <location filename="../src/efibootdata.cpp" line="969"/>
         <source>number</source>
         <translation>število</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="803"/>
-        <location filename="../src/efibootdata.cpp" line="808"/>
-        <location filename="../src/efibootdata.cpp" line="813"/>
-        <location filename="../src/efibootdata.cpp" line="818"/>
-        <location filename="../src/efibootdata.cpp" line="823"/>
+        <location filename="../src/efibootdata.cpp" line="843"/>
+        <location filename="../src/efibootdata.cpp" line="848"/>
+        <location filename="../src/efibootdata.cpp" line="853"/>
+        <location filename="../src/efibootdata.cpp" line="858"/>
+        <location filename="../src/efibootdata.cpp" line="863"/>
         <source>bool</source>
         <translation type="unfinished">bool</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="828"/>
-        <location filename="../src/efibootdata.cpp" line="872"/>
-        <location filename="../src/efibootdata.cpp" line="918"/>
+        <location filename="../src/efibootdata.cpp" line="868"/>
+        <location filename="../src/efibootdata.cpp" line="912"/>
+        <location filename="../src/efibootdata.cpp" line="958"/>
         <source>array</source>
         <translation type="unfinished">array</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="840"/>
-        <location filename="../src/efibootdata.cpp" line="884"/>
-        <location filename="../src/efibootdata.cpp" line="999"/>
+        <location filename="../src/efibootdata.cpp" line="880"/>
+        <location filename="../src/efibootdata.cpp" line="924"/>
+        <location filename="../src/efibootdata.cpp" line="1039"/>
         <source>string</source>
         <translation type="unfinished">string</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="862"/>
-        <location filename="../src/efibootdata.cpp" line="898"/>
+        <location filename="../src/efibootdata.cpp" line="902"/>
+        <location filename="../src/efibootdata.cpp" line="938"/>
         <source>%1: unknown os indication</source>
         <translation type="unfinished">%1: unknown os indication</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="941"/>
-        <location filename="../src/efibootdata.cpp" line="969"/>
-        <location filename="../src/efibootdata.cpp" line="994"/>
+        <location filename="../src/efibootdata.cpp" line="981"/>
+        <location filename="../src/efibootdata.cpp" line="1009"/>
         <location filename="../src/efibootdata.cpp" line="1034"/>
-        <location filename="../src/efibootdata.cpp" line="1139"/>
-        <location filename="../src/efibootdata.cpp" line="1189"/>
+        <location filename="../src/efibootdata.cpp" line="1075"/>
+        <location filename="../src/efibootdata.cpp" line="1180"/>
+        <location filename="../src/efibootdata.cpp" line="1230"/>
         <source>object</source>
         <translation type="unfinished">object</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="953"/>
-        <location filename="../src/efibootdata.cpp" line="1152"/>
+        <location filename="../src/efibootdata.cpp" line="993"/>
+        <location filename="../src/efibootdata.cpp" line="1193"/>
         <source>hexadecimal number</source>
         <translation type="unfinished">hexadecimal number</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="975"/>
+        <location filename="../src/efibootdata.cpp" line="1015"/>
         <source>%1: failed parsing</source>
         <translation type="unfinished">%1: failed parsing</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1006"/>
-        <location filename="../src/efibootdata.cpp" line="1202"/>
+        <location filename="../src/efibootdata.cpp" line="1046"/>
+        <location filename="../src/efibootdata.cpp" line="1243"/>
         <source>Failed to import some EFI Boot Manager entries:
 
   - %1</source>
@@ -633,7 +650,7 @@
   - %1</translation>
     </message>
     <message>
-        <location filename="../src/efibootdata.cpp" line="1044"/>
+        <location filename="../src/efibootdata.cpp" line="1085"/>
         <source>object(raw_data: string, efi_attributes: number)</source>
         <extracomment>Expected JSON structure, thrown as error description. raw_data and efi_attributes are field names in JSON file</extracomment>
         <translation type="unfinished">object(raw_data: string, efi_attributes: number)</translation>
@@ -668,8 +685,8 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="72"/>
-        <location filename="../src/efibooteditor.cpp" line="351"/>
-        <location filename="../src/efibooteditor.cpp" line="364"/>
+        <location filename="../src/efibooteditor.cpp" line="372"/>
+        <location filename="../src/efibooteditor.cpp" line="385"/>
         <source>Boot</source>
         <translation type="unfinished">Boot</translation>
     </message>
@@ -688,7 +705,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="134"/>
-        <location filename="../src/efibooteditor.cpp" line="354"/>
+        <location filename="../src/efibooteditor.cpp" line="375"/>
         <source>Driver</source>
         <translation type="unfinished">Driver</translation>
     </message>
@@ -707,7 +724,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="196"/>
-        <location filename="../src/efibooteditor.cpp" line="357"/>
+        <location filename="../src/efibooteditor.cpp" line="378"/>
         <source>System Preparation</source>
         <translation type="unfinished">System Preparation</translation>
     </message>
@@ -726,7 +743,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="258"/>
-        <location filename="../src/efibooteditor.cpp" line="360"/>
+        <location filename="../src/efibooteditor.cpp" line="381"/>
         <source>Platform Recovery</source>
         <translation type="unfinished">Platform Recovery</translation>
     </message>
@@ -1328,7 +1345,7 @@
     </message>
     <message>
         <location filename="../src/form/efibooteditor.ui" line="1280"/>
-        <location filename="../src/efibooteditor.cpp" line="235"/>
+        <location filename="../src/efibooteditor.cpp" line="238"/>
         <source>About EFI Boot Editor</source>
         <translation type="unfinished">About EFI Boot Editor</translation>
     </message>
@@ -1398,51 +1415,51 @@
         <translation type="unfinished">Are you sure you want to reorder the boot entries?&lt;br/&gt;All indexes will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="183"/>
+        <location filename="../src/efibooteditor.cpp" line="186"/>
         <source>Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</source>
         <translation type="unfinished">Are you sure you want to save?&lt;br/&gt;Your EFI configuration will be overwritten!</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
         <source>Open boot configuration dump</source>
         <translation type="unfinished">Open boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="192"/>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="195"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>JSON documents (*.json)</source>
         <translation type="unfinished">JSON documents (*.json)</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="210"/>
+        <location filename="../src/efibooteditor.cpp" line="213"/>
         <source>Save boot configuration dump</source>
         <translation type="unfinished">Save boot configuration dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="222"/>
+        <location filename="../src/efibooteditor.cpp" line="225"/>
         <source>Save raw EFI dump</source>
         <translation type="unfinished">Save raw EFI dump</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="237"/>
+        <location filename="../src/efibooteditor.cpp" line="240"/>
         <source>&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</source>
         <extracomment>About dialog</extracomment>
         <translation type="unfinished">&lt;h1&gt;EFI Boot Editor&lt;/h1&gt;&lt;p&gt;Version &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Boot Editor for (U)EFI based systems.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="245"/>
+        <location filename="../src/efibooteditor.cpp" line="248"/>
         <source>&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</source>
         <extracomment>About dialog details</extracomment>
         <translation type="unfinished">&lt;p&gt;&lt;a href=&apos;%1&apos;&gt;Website&lt;/a&gt;&lt;/p&gt;&lt;p&gt;The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.&lt;/p&gt;&lt;p&gt;License: &lt;a href=&apos;https://www.gnu.org/licenses/lgpl.html&apos;&gt;GNU LGPL Version 3&lt;/a&gt;&lt;/p&gt;&lt;p&gt;On Linux uses &lt;a href=&apos;https://github.com/rhboot/efivar&apos;&gt;efivar&lt;/a&gt; for EFI variables access.&lt;/p&gt;&lt;p&gt;Uses Tango Icons as fallback icons.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="297"/>
+        <location filename="../src/efibooteditor.cpp" line="300"/>
         <source>Reorder %1 entries</source>
         <translation type="unfinished">Reorder %1 entries</translation>
     </message>
     <message>
-        <location filename="../src/efibooteditor.cpp" line="393"/>
+        <location filename="../src/efibooteditor.cpp" line="414"/>
         <source>Are you sure you want to quit?</source>
         <translation type="unfinished">Are you sure you want to quit?</translation>
     </message>
@@ -2491,8 +2508,8 @@
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unknown data.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/filepathdialog.cpp" line="571"/>
-        <location filename="../src/filepathdialog.cpp" line="620"/>
+        <location filename="../src/filepathdialog.cpp" line="565"/>
+        <location filename="../src/filepathdialog.cpp" line="607"/>
         <source>Couldn&apos;t change Vendor data format!</source>
         <translation type="unfinished">Couldn&apos;t change Vendor data format!</translation>
     </message>


### PR DESCRIPTION
This allows to edit valid entries and reorder them without touching possibly custom vendor data. Previously all unknown/broken boot order entries were removed on save.