### PR TITLE
Windows entry removal fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Boot Editor for (U)EFI based systems.
 
 There is also a command-line interface for quick backup/restore functionality:
 
-```
+```shell
 Usage: efibooteditor [options]
 Boot Editor for (U)EFI based systems.
 

--- a/src/efibootdata.cpp
+++ b/src/efibootdata.cpp
@@ -278,7 +278,9 @@ void EFIBootData::save()
 
             for(const auto &[prefix, model]: BOOT_ENTRIES)
             {
-                (void)model;
+                if(model.options & BootEntryListModel::ReadOnly)
+                    continue;
+
                 if(is_bootentry(tname, QStringToStdTString(prefix)))
                     return true;
             }

--- a/src/efivar-lite.win32.c
+++ b/src/efivar-lite.win32.c
@@ -95,8 +95,10 @@ int efi_get_variable(efi_guid_t guid, const TCHAR *name, uint8_t **data, size_t 
 int efi_del_variable(efi_guid_t guid, const TCHAR *name)
 {
     // setting nSize (data_size) = 0 => deletes variable
-    // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setfirmwareenvironmentvariableexa#parameters
-    return efi_set_variable(guid, name, NULL, 0, 0, 0);
+    // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setfirmwareenvironmentvariablea#parameters
+    BOOL ret = SetFirmwareEnvironmentVariable(name, guid.data, NULL, 0);
+    last_winapi_function = _T("SetFirmwareEnvironmentVariable");
+    return ret == 0 ? -1 : 0;
 }
 
 int efi_set_variable(efi_guid_t guid, const TCHAR *name, uint8_t *data, size_t data_size, uint32_t attributes, mode_t mode)


### PR DESCRIPTION
- It seems Windows sometimes expects proper `dwAttributes` in `SetFirmwareEnvironmentVariableEx` even when removing the variable altogether. Switching to simpler `SetFirmwareEnvironmentVariable` for deletions.
- PlatformRecovery entries (which are readonly) were erroneously tried to be removed as well