### PR TITLE
efiboot: fix error handling

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -63,12 +63,23 @@ typedef char TCHAR;
 #pragma clang diagnostic ignored "-Wreserved-macro-identifier"
 #endif
 #define _T
+#define _TRUNCATE STATIC_CAST(size_t)(-1)
+inline int _tcsncpy_s(TCHAR *buffer, size_t size, TCHAR *src, size_t _size)
+{
+    (void)_size;
+    return !buffer || *strncpy(buffer, src, size - 1) == 0;
+}
+
 inline int _tcserror_s(TCHAR *buffer, size_t size, int errnum)
 {
 #if defined(__APPLE__) || ((_POSIX_C_SOURCE >= 200112L) && !defined(_GNU_SOURCE))
     return strerror_r(errnum, buffer, size);
 #else
-    return strerror_r(errnum, buffer, size) == NULL;
+    TCHAR *msg = strerror_r(errnum, buffer, size);
+    if(msg == NULL)
+        return 0;
+
+    return _tcsncpy_s(buffer, size, msg, _TRUNCATE);
 #endif
 }
 

--- a/include/efiboot.h
+++ b/include/efiboot.h
@@ -3628,11 +3628,10 @@ inline tstring get_error_trace()
         if(rc < 0)
             output += _T("error fetching trace value\n");
 
-        if(rc == 0)
+        if(rc <= 0)
             break;
 
-        rc = _tcserror_s(error_str, ERROR_STR_BUFFER_SIZE - 1, error);
-        if(rc != 0)
+        if(_tcserror_s(error_str, ERROR_STR_BUFFER_SIZE - 1, error) != 0)
             output += _T("error translating error code to string\n");
 
         output += filename;
@@ -3642,12 +3641,19 @@ inline tstring get_error_trace()
         output += function;
         output += _T("(): ");
         output += error_str;
-        output += _T(": ");
+        output += _T("[");
+        output += to_tstring(error);
+        output += _T("]: ");
         output += message;
         output += _T("\n");
     }
 
     return output;
+}
+
+inline void error_clear()
+{
+    efi_error_clear();
 }
 
 } // namespace EFIBoot

--- a/include/efivar-lite/efivar-lite.h
+++ b/include/efivar-lite/efivar-lite.h
@@ -80,3 +80,4 @@ void efi_set_get_next_variable_name_progress_cb(void (*progress_cb)(size_t, size
 int efi_guid_cmp(const efi_guid_t *a, const efi_guid_t *b);
 
 int efi_error_get(unsigned int n, TCHAR **const filename, TCHAR **const function, int *line, TCHAR **const message, int *error) ATTR_NONNULL(2, 3, 4, 5, 6);
+void efi_error_clear(void);

--- a/src/efibootdata.cpp
+++ b/src/efibootdata.cpp
@@ -348,6 +348,9 @@ void EFIBootData::save()
                 emit error(tr("Error removing %1").arg(order_name), QStringFromStdTString(EFIBoot::get_error_trace()));
                 return;
             }
+
+            // EFIBoot::get_variable above might've thrown an error, we don't care about it
+            EFIBoot::error_clear();
         }
         else
         {
@@ -403,6 +406,9 @@ void EFIBootData::save()
             emit error(tr("Error removing %1").arg("Apple/boot-args"), QStringFromStdTString(EFIBoot::get_error_trace()));
             return;
         }
+
+        // EFIBoot::get_variable above might've thrown an error, we don't care about it
+        EFIBoot::error_clear();
     }
     else
     {

--- a/src/efivar-lite.darwin.c
+++ b/src/efivar-lite.darwin.c
@@ -176,3 +176,8 @@ int efi_error_get(unsigned int n, char **const filename, char **const function, 
     *message = mach_error_string(err);
     return 1;
 }
+
+void efi_error_clear(void)
+{
+    // Nothing to do
+}

--- a/src/efivar-lite.win32.c
+++ b/src/efivar-lite.win32.c
@@ -215,3 +215,8 @@ int efi_error_get(unsigned int n, TCHAR **const filename, TCHAR **const function
     *message = error_buffer;
     return 1;
 }
+
+void efi_error_clear(void)
+{
+    // Nothing to do
+}


### PR DESCRIPTION
Noticed in https://github.com/Neverous/efibooteditor/issues/218 that traces are invalid.
This fixes them, now full traces should be presented and ignored errors are cleared immediately.