### PR TITLE
windows, driveinfo: make disk choices look similar to Disk Management

### DIFF
--- a/src/driveinfo.win32.cpp
+++ b/src/driveinfo.win32.cpp
@@ -3,6 +3,7 @@
 
 #include "driveinfo.h"
 
+#include <QObject>
 #include <Windows.h>
 #include <array>
 
@@ -21,49 +22,65 @@ QVector<DriveInfo> DriveInfo::getAll(bool refresh)
 
     for(BOOL volume_found = true; volume_found; volume_found = FindNextVolume(volume_handle, volume_name.data(), static_cast<DWORD>(volume_name.size())))
     {
-        DriveInfo driveinfo{};
-        std::array<TCHAR, MAX_PATH> device_name{};
         size_t length = _tcsnccnt(volume_name.data(), volume_name.size());
         if(length != 49u)
             continue;
 
         volume_name[length - 1u] = _T('\0');
-        if(!QueryDosDevice(&volume_name[4], device_name.data(), static_cast<DWORD>(device_name.size())))
-            continue;
-
+        HANDLE device_handle = CreateFile(volume_name.data(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
         volume_name[length - 1u] = _T('\\');
-
-        PARTITION_INFORMATION_EX partition_information{};
-
-        device_name[4] = _T('\\');
-        device_name[5] = _T('\\');
-        device_name[6] = _T('.');
-        HANDLE device_handle = CreateFile(&device_name[4], 0, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
-        device_name[4] = _T('i');
-        device_name[5] = _T('c');
-        device_name[6] = _T('e');
         if(device_handle == INVALID_HANDLE_VALUE)
             continue;
 
-        if(!DeviceIoControl(device_handle, IOCTL_DISK_GET_PARTITION_INFO_EX, nullptr, 0, &partition_information, sizeof(partition_information), nullptr, nullptr))
+        STORAGE_DEVICE_NUMBER device_number{};
+        if(!DeviceIoControl(device_handle, IOCTL_STORAGE_GET_DEVICE_NUMBER, nullptr, 0, &device_number, sizeof(device_number), nullptr, nullptr))
+        {
+            CloseHandle(device_handle);
+            continue;
+        }
+
+        PARTITION_INFORMATION_EX partition_info{};
+        if(!DeviceIoControl(device_handle, IOCTL_DISK_GET_PARTITION_INFO_EX, nullptr, 0, &partition_info, sizeof(partition_info), nullptr, nullptr))
         {
             CloseHandle(device_handle);
             continue;
         }
 
         CloseHandle(device_handle);
-        driveinfo.name = QStringFromTCharArray(&device_name[8]);
-        switch(partition_information.PartitionStyle)
+
+        DriveInfo driveinfo{};
+        switch(device_number.DeviceType)
+        {
+        case FILE_DEVICE_CD_ROM:
+            driveinfo.name = QObject::tr("CD-ROM %1").arg(device_number.DeviceNumber);
+            break;
+
+        case FILE_DEVICE_DISK:
+            driveinfo.name = QObject::tr("Disk %1 partition %2").arg(device_number.DeviceNumber).arg(partition_info.PartitionNumber);
+            break;
+
+        default:
+            driveinfo.name = QObject::tr("Device %1 number %2 partition %3").arg(toHex(device_number.DeviceType)).arg(device_number.DeviceNumber).arg(partition_info.PartitionNumber);
+            break;
+        }
+
+        QString label{};
+        if(std::array<TCHAR, MAX_PATH> volume_label{}; GetVolumeInformation(volume_name.data(), volume_label.data(), static_cast<DWORD>(volume_label.size()), nullptr, nullptr, nullptr, nullptr, 0))
+            label = QStringFromTCharArray(volume_label.data());
+
+        switch(partition_info.PartitionStyle)
         {
         case PARTITION_STYLE_GPT:
             driveinfo.signature_type = DriveInfo::SIGNATURE::GUID;
-            driveinfo.name += QString(" (%1)").arg(QString::fromWCharArray(partition_information.Gpt.Name));
-            driveinfo.signature = partition_information.Gpt.PartitionId;
+            if(label.isEmpty())
+                label = QString::fromWCharArray(partition_info.Gpt.Name);
+
+            driveinfo.signature = partition_info.Gpt.PartitionId;
             break;
 
         case PARTITION_STYLE_MBR:
             driveinfo.signature_type = DriveInfo::SIGNATURE::MBR;
-            driveinfo.signature = partition_information.Mbr.PartitionId;
+            driveinfo.signature = partition_info.Mbr.PartitionId;
             break;
 
         case PARTITION_STYLE_RAW:
@@ -71,9 +88,12 @@ QVector<DriveInfo> DriveInfo::getAll(bool refresh)
             break;
         }
 
-        driveinfo.partition = partition_information.PartitionNumber;
-        driveinfo.start = static_cast<uint64_t>(partition_information.StartingOffset.QuadPart);
-        driveinfo.size = static_cast<uint64_t>(partition_information.PartitionLength.QuadPart);
+        if(!label.isEmpty())
+            driveinfo.name += QString(" (%1)").arg(label);
+
+        driveinfo.partition = partition_info.PartitionNumber;
+        driveinfo.start = static_cast<uint64_t>(partition_info.StartingOffset.QuadPart);
+        driveinfo.size = static_cast<uint64_t>(partition_info.PartitionLength.QuadPart);
         all.append(driveinfo);
     }
 

--- a/translations/efibooteditor_de.ts
+++ b/translations/efibooteditor_de.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_en.ts
+++ b/translations/efibooteditor_en.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_hu.ts
+++ b/translations/efibooteditor_hu.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_it.ts
+++ b/translations/efibooteditor_it.ts
@@ -5514,5 +5514,20 @@ Se SignatureType è 2, questo campo contiene una firma a 16 byte.&lt;/p&gt;&lt;/
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>Sposta percorso del file voce %1 &apos;%2&apos; dalla posizione &apos;%3&apos; alla &apos;%4&apos;</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_ko.ts
+++ b/translations/efibooteditor_ko.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>%1 항목 &quot;%2&quot; 파일 경로를 %3 위치에서 %4 위치로 이동</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_nb_NO.ts
+++ b/translations/efibooteditor_nb_NO.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_pl.ts
+++ b/translations/efibooteditor_pl.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>Przeniesienie wpisu %1 &quot;%2&quot; ścieżka z pozycji %3 do %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_ru.ts
+++ b/translations/efibooteditor_ru.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_sk.ts
+++ b/translations/efibooteditor_sk.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>Presunúť %1 položku &quot;%2&quot; cesta k súboru z pozície %3 na %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_sl.ts
+++ b/translations/efibooteditor_sl.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_sv.ts
+++ b/translations/efibooteditor_sv.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_tr.ts
+++ b/translations/efibooteditor_tr.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation type="unfinished">Move %1 entry &quot;%2&quot; file path from position %3 to %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_zh_Hans.ts
+++ b/translations/efibooteditor_zh_Hans.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>将 %1 条目 &quot;%2&quot; 文件路径从位置 %3 移动到 %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>

--- a/translations/efibooteditor_zh_Hant.ts
+++ b/translations/efibooteditor_zh_Hant.ts
@@ -5514,5 +5514,20 @@ If SignatureType is 2, this field contains a 16 byte signature.&lt;/p&gt;&lt;/bo
         <source>Move %1 entry &quot;%2&quot; file path from position %3 to %4</source>
         <translation>移動 %1 條目「%2」檔案路徑位置從 %3 至 %4</translation>
     </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="55"/>
+        <source>CD-ROM %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="59"/>
+        <source>Disk %1 partition %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/driveinfo.win32.cpp" line="63"/>
+        <source>Device %1 number %2 partition %3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 </TS>


### PR DESCRIPTION
Potentially addresses https://github.com/Neverous/efibooteditor/issues/291 as it's working now with pure Volumes instead of querying DosDevice information for nice name.